### PR TITLE
Support async interaction with Dynamo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,6 +20,7 @@ libraryDependencies ++= Seq(
 )
 // for simulacrum
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
+addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
 
 scalacOptions := Seq(
   "-deprecation",

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ libraryDependencies ++= Seq(
 )
 // for simulacrum
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
 
 scalacOptions := Seq(
   "-deprecation",

--- a/src/main/scala/com/gu/scanamo/DynamoResultStream.scala
+++ b/src/main/scala/com/gu/scanamo/DynamoResultStream.scala
@@ -21,7 +21,7 @@ trait DynamoResultStream[Req, Res] {
     def streamMore(lastKey: Option[java.util.Map[String, AttributeValue]]): ScanamoOps[Streaming[ValidatedNel[DynamoReadError, T]]] = {
       for {
         queryResult <- exec(lastKey.foldLeft(req)(withExclusiveStartKey(_, _)))
-        results = Streaming.fromIterable(items(queryResult).asScala.map(Scanamo.read[T]))
+        results = Streaming.fromIterable(items(queryResult).asScala.map(ScanamoFree.read[T]))
         resultStream <-
           Option(lastEvaluatedKey(queryResult)).foldLeft(
             Free.pure[ScanamoOpsA, Streaming[ValidatedNel[DynamoReadError, T]]](results)

--- a/src/main/scala/com/gu/scanamo/DynamoResultStream.scala
+++ b/src/main/scala/com/gu/scanamo/DynamoResultStream.scala
@@ -2,23 +2,34 @@ package com.gu.scanamo
 
 import java.util
 
-import cats.Later
+import cats.{Later, Monad}
 import cats.data._
+import cats.free.Free
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model._
+
 import collection.convert.decorateAsScala._
 
 trait DynamoResultStream[Req, Res] {
   def items(res: Res): java.util.List[java.util.Map[String, AttributeValue]]
   def lastEvaluatedKey(res: Res): java.util.Map[String, AttributeValue]
   def withExclusiveStartKey(req: Req, key: java.util.Map[String, AttributeValue]): Req
-  def exec(client: AmazonDynamoDB)(req: Req): Res
+  def exec(req: Req): ScanamoOps[Res]
 
-  def stream[T](client: AmazonDynamoDB)(req: Req)(implicit f: DynamoFormat[T]): Streaming[ValidatedNel[DynamoReadError, T]] = {
-    def streamMore(lastKey: Option[java.util.Map[String, AttributeValue]]): Streaming[ValidatedNel[DynamoReadError, T]] = {
-      val queryResult = exec(client)(lastKey.foldLeft(req)(withExclusiveStartKey(_, _)))
-      val results = Streaming.fromIterable(items(queryResult).asScala.map(Scanamo.read[T]))
-      Option(lastEvaluatedKey(queryResult)).foldLeft(results)((is, k) => is ++ Later(streamMore(Some(k))))
+  def stream[T: DynamoFormat](req: Req): ScanamoOps[Streaming[ValidatedNel[DynamoReadError, T]]] = {
+
+    def streamMore(lastKey: Option[java.util.Map[String, AttributeValue]]): ScanamoOps[Streaming[ValidatedNel[DynamoReadError, T]]] = {
+      for {
+        queryResult <- exec(lastKey.foldLeft(req)(withExclusiveStartKey(_, _)))
+        results = Streaming.fromIterable(items(queryResult).asScala.map(Scanamo.read[T]))
+        resultStream <-
+          Option(lastEvaluatedKey(queryResult)).foldLeft(
+            Free.pure[ScanamoOpsA, Streaming[ValidatedNel[DynamoReadError, T]]](results)
+          )((rs, k) => for {
+            items <- rs
+            more <- streamMore(Some(k))
+          } yield items ++ more)
+      } yield resultStream
     }
     streamMore(None)
   }
@@ -30,7 +41,8 @@ object DynamoResultStream {
     override def lastEvaluatedKey(res: ScanResult): util.Map[String, AttributeValue] = res.getLastEvaluatedKey
     override def withExclusiveStartKey(req: ScanRequest, key: util.Map[String, AttributeValue]): ScanRequest =
       req.withExclusiveStartKey(key)
-    override def exec(client: AmazonDynamoDB)(req: ScanRequest): ScanResult = client.scan(req)
+
+    override def exec(req: ScanRequest): ScanamoOps[ScanResult] = ScanamoOps.scan(req)
   }
 
   object QueryResultStream extends DynamoResultStream[QueryRequest, QueryResult] {
@@ -38,6 +50,7 @@ object DynamoResultStream {
     override def lastEvaluatedKey(res: QueryResult): util.Map[String, AttributeValue] = res.getLastEvaluatedKey
     override def withExclusiveStartKey(req: QueryRequest, key: util.Map[String, AttributeValue]): QueryRequest =
       req.withExclusiveStartKey(key)
-    override def exec(client: AmazonDynamoDB)(req: QueryRequest): QueryResult = client.query(req)
+
+    override def exec(req: QueryRequest): ScanamoOps[QueryResult] = ScanamoOps.query(req)
   }
 }

--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -177,11 +177,9 @@ object Scanamo {
     * 100
     * }}}
     */
-  def scan[T](client: AmazonDynamoDB)(tableName: String)(implicit f: DynamoFormat[T]): Streaming[ValidatedNel[DynamoReadError, T]] = {
-    ScanResultStream.stream[T](client)(
-      new ScanRequest().withTableName(tableName)
-    )
-  }
+  def scan[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)
+    : Streaming[ValidatedNel[DynamoReadError, T]] =
+    exec(client)(ScanamoFree.scan(tableName))
 
   /**
     * Perform a query against a table
@@ -230,14 +228,9 @@ object Scanamo {
     * List(Valid(Transport(Underground,Central)), Valid(Transport(Underground,Circle)))
     * }}}
     */
-  def query[T](client: AmazonDynamoDB)(tableName: String)(keyCondition: Query[_])(
-    implicit f: DynamoFormat[T]
-  ) : Streaming[ValidatedNel[DynamoReadError, T]] = {
-
-    QueryResultStream.stream[T](client)(
-      queryRequest(tableName)(keyCondition)
-    )
-  }
+  def query[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(query: Query[_])
+    : Streaming[ValidatedNel[DynamoReadError, T]] =
+    exec(client)(ScanamoFree.query(tableName)(query))
 
   /**
     * {{{

--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -5,7 +5,9 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model._
 
 /**
-  * Scanamo provides a simplified interface for reading and writing case classes to DynamoDB
+  * Provides a simplified interface for reading and writing case classes to DynamoDB
+  *
+  * To avoid blocking, use [[com.gu.scanamo.ScanamoAsync]]
   */
 object Scanamo {
 

--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -34,7 +34,7 @@ object Scanamo {
     * }}}
     */
   def put[T](client: AmazonDynamoDB)(tableName: String)(item: T)(implicit f: DynamoFormat[T]): PutItemResult =
-    client.putItem(putRequest(tableName)(item))
+    ScanamoFree.put(tableName)(item).foldMap(ScanamoInterpreters.id(client))
 
   /**
     * Gets a single item from a table by a unique key
@@ -84,7 +84,7 @@ object Scanamo {
     */
   def get[T](client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_])
     (implicit ft: DynamoFormat[T]): Option[ValidatedNel[DynamoReadError, T]] =
-    Option(client.getItem(getRequest(tableName)(key)).getItem).map(read[T])
+    ScanamoFree.get[T](tableName)(key).foldMap(ScanamoInterpreters.id(client))
 
   /**
     * Returns all the items in the table with matching keys

--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -6,13 +6,6 @@ import com.amazonaws.services.dynamodbv2.model._
 
 /**
   * Scanamo provides a simplified interface for reading and writing case classes to DynamoDB
-  *
-  * The examples in method documentation assume the following table has been created:
-  * {{{
-  * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-  * >>> val client = LocalDynamoDB.client()
-  * >>> val createTableResult = LocalDynamoDB.createTable(client)("farmers")('name -> S)
-  * }}}
   */
 object Scanamo {
 
@@ -22,14 +15,17 @@ object Scanamo {
     * Puts a single item into a table
     *
     * {{{
-    * >>> val client = LocalDynamoDB.client()
-    *
     * >>> case class Farm(animals: List[String])
     * >>> case class Farmer(name: String, age: Long, farm: Farm)
     *
-    * >>> val putResult = Scanamo.put(client)("farmers")(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
     * >>> import com.gu.scanamo.syntax._
-    * >>> Scanamo.get[Farmer](client)("farmers")('name -> "McDonald")
+    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> val client = LocalDynamoDB.client()
+    *
+    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
+    * ...   Scanamo.put(client)("farmers")(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
+    * ...   Scanamo.get[Farmer](client)("farmers")('name -> "McDonald")
+    * ... }
     * Some(Valid(Farmer(McDonald,156,Farm(List(sheep, cow)))))
     * }}}
     */
@@ -40,13 +36,15 @@ object Scanamo {
     * Gets a single item from a table by a unique key
     *
     * {{{
-    * >>> val client = LocalDynamoDB.client()
     * >>> case class Rabbit(name: String)
+    *
+    * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-    * >>> val createTableResult = LocalDynamoDB.createTable(client)("rabbits")('name -> S)
-    * >>> val multiPut = Scanamo.putAll(client)("rabbits")((
+    * >>> LocalDynamoDB.withTable(client)("rabbits")('name -> S) {
+    * ...   Scanamo.putAll(client)("rabbits")((
     * ...   for { _ <- 0 until 100 } yield Rabbit(util.Random.nextString(500))).toList)
-    * >>> Scanamo.scan[Rabbit](client)("rabbits").toList.size
+    * ...   Scanamo.scan[Rabbit](client)("rabbits").toList.size
+    * ... }
     * 100
     * }}}
     */
@@ -55,28 +53,34 @@ object Scanamo {
 
   /**
     * {{{
-    * >>> val client = LocalDynamoDB.client()
-    *
     * >>> case class Farm(animals: List[String])
     * >>> case class Farmer(name: String, age: Long, farm: Farm)
     *
-    * >>> val putResult = Scanamo.put(client)("farmers")(Farmer("Maggot", 75L, Farm(List("dog"))))
-    * >>> Scanamo.get[Farmer](client)("farmers")(UniqueKey(KeyEquals('name, "Maggot")))
+    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> val client = LocalDynamoDB.client()
+    *
+    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
+    * ...   Scanamo.put(client)("farmers")(Farmer("Maggot", 75L, Farm(List("dog"))))
+    * ...   Scanamo.get[Farmer](client)("farmers")(UniqueKey(KeyEquals('name, "Maggot")))
+    * ... }
     * Some(Valid(Farmer(Maggot,75,Farm(List(dog)))))
     * }}}
     * or with some added syntactic sugar:
     * {{{
     * >>> import com.gu.scanamo.syntax._
-    * >>> Scanamo.get[Farmer](client)("farmers")('name -> "Maggot")
+    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
+    * ...   Scanamo.put(client)("farmers")(Farmer("Maggot", 75L, Farm(List("dog"))))
+    * ...   Scanamo.get[Farmer](client)("farmers")('name -> "Maggot")
+    * ... }
     * Some(Valid(Farmer(Maggot,75,Farm(List(dog)))))
     * }}}
     * Can also be used with tables that have both a hash and a range key:
     * {{{
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-    * >>> val createTableResult = LocalDynamoDB.createTable(client)("engines")('name -> S, 'number -> N)
     * >>> case class Engine(name: String, number: Int)
-    * >>> val thomas = Scanamo.put(client)("engines")(Engine("Thomas", 1))
-    * >>> Scanamo.get[Engine](client)("engines")('name -> "Thomas" and 'number -> 1)
+    * >>> LocalDynamoDB.withTable(client)("engines")('name -> S, 'number -> N) {
+    * ...   Scanamo.put(client)("engines")(Engine("Thomas", 1))
+    * ...   Scanamo.get[Engine](client)("engines")('name -> "Thomas" and 'number -> 1)
+    * ... }
     * Some(Valid(Engine(Thomas,1)))
     * }}}
     */
@@ -90,34 +94,39 @@ object Scanamo {
     * Results are returned in the same order as the keys are provided
     *
     * {{{
-    * >>> val client = LocalDynamoDB.client()
-    *
     * >>> case class Farm(animals: List[String])
     * >>> case class Farmer(name: String, age: Long, farm: Farm)
     *
-    * >>> val putResult = Scanamo.putAll(client)("farmers")(List(
-    * ...   Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
-    * ... ))
-    * >>> Scanamo.getAll[Farmer](client)("farmers")(UniqueKeys(KeyList('name, List("Boggis", "Bean"))))
+    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> val client = LocalDynamoDB.client()
+    *
+    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
+    * ...   Scanamo.putAll(client)("farmers")(List(
+    * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
+    * ...   ))
+    * ...   Scanamo.getAll[Farmer](client)("farmers")(UniqueKeys(KeyList('name, List("Boggis", "Bean"))))
+    * ... }
     * List(Valid(Farmer(Boggis,43,Farm(List(chicken)))), Valid(Farmer(Bean,55,Farm(List(turkey)))))
     * }}}
     * or with some added syntactic sugar:
     * {{{
     * >>> import com.gu.scanamo.syntax._
-    * >>> Scanamo.getAll[Farmer](client)("farmers")('name -> List("Boggis", "Bean"))
+    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
+    * ...   Scanamo.putAll(client)("farmers")(List(
+    * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
+    * ...   ))
+    * ...   Scanamo.getAll[Farmer](client)("farmers")('name -> List("Boggis", "Bean"))
+    * ... }
     * List(Valid(Farmer(Boggis,43,Farm(List(chicken)))), Valid(Farmer(Bean,55,Farm(List(turkey)))))
     * }}}
     * You can also retrieve items from a table with both a hash and range key
     * {{{
-    * >>> import com.gu.scanamo.syntax._
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-    *
     * >>> case class Doctor(actor: String, regeneration: Int)
-    * >>> val doctorsTableResult = LocalDynamoDB.createTable(client)("doctors")('actor -> S, 'regeneration -> N)
-    *
-    * >>> val putDoctorResult = Scanamo.putAll(client)("doctors")(
-    * ...   List(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-    * >>> Scanamo.getAll[Doctor](client)("doctors")(('actor and 'regeneration) -> List("McCoy" -> 9, "Ecclestone" -> 11))
+    * >>> LocalDynamoDB.withTable(client)("doctors")('actor -> S, 'regeneration -> N) {
+    * ...   Scanamo.putAll(client)("doctors")(
+    * ...     List(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
+    * ...   Scanamo.getAll[Doctor](client)("doctors")(('actor and 'regeneration) -> List("McCoy" -> 9, "Ecclestone" -> 11))
+    * ... }
     * List(Valid(Doctor(McCoy,9)), Valid(Doctor(Ecclestone,11)))
     * }}}
     */
@@ -130,15 +139,18 @@ object Scanamo {
     * Deletes a single item from a table by a unique key
     *
     * {{{
-    * >>> val client = LocalDynamoDB.client()
-    *
     * >>> case class Farm(animals: List[String])
     * >>> case class Farmer(name: String, age: Long, farm: Farm)
     *
-    * >>> val putResult = Scanamo.put(client)("farmers")(Farmer("McGregor", 62L, Farm(List("rabbit"))))
+    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> import com.gu.scanamo.syntax._
-    * >>> val deleteResult = Scanamo.delete(client)("farmers")('name -> "McGregor")
-    * >>> Scanamo.get[Farmer](client)("farmers")('name -> "McGregor")
+    * >>> val client = LocalDynamoDB.client()
+    *
+    * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
+    * ...   Scanamo.put(client)("farmers")(Farmer("McGregor", 62L, Farm(List("rabbit"))))
+    * ...   Scanamo.delete(client)("farmers")('name -> "McGregor")
+    * ...   Scanamo.get[Farmer](client)("farmers")('name -> "McGregor")
+    * ... }
     * None
     * }}}
     */
@@ -150,25 +162,28 @@ object Scanamo {
     *
     * Does not cache results by default
     * {{{
-    * >>> val client = LocalDynamoDB.client()
-    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-    * >>> val createTableResult = LocalDynamoDB.createTable(client)("bears")('name -> S)
-    *
     * >>> case class Bear(name: String, favouriteFood: String)
     *
-    * >>> val r1 = Scanamo.put(client)("bears")(Bear("Pooh", "honey"))
-    * >>> val r2 = Scanamo.put(client)("bears")(Bear("Yogi", "picnic baskets"))
-    * >>> Scanamo.scan[Bear](client)("bears").toList
+    * >>> val client = LocalDynamoDB.client()
+    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    *
+    * >>> LocalDynamoDB.withTable(client)("bears")('name -> S) {
+    * ...   Scanamo.put(client)("bears")(Bear("Pooh", "honey"))
+    * ...   Scanamo.put(client)("bears")(Bear("Yogi", "picnic baskets"))
+    * ...   Scanamo.scan[Bear](client)("bears").toList
+    * ... }
     * List(Valid(Bear(Pooh,honey)), Valid(Bear(Yogi,picnic baskets)))
     * }}}
     * Pagination is handled internally with `Streaming` result retrieving pages as necessary
     * {{{
-    * >>> val lemmingTableResult = LocalDynamoDB.createTable(client)("lemmings")('name -> S)
     * >>> case class Lemming(name: String, stuff: String)
-    * >>> val lemmingResults = Scanamo.putAll(client)("lemmings")(
-    * ...   (for { _ <- 0 until 100 } yield Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toList
-    * ... )
-    * >>> Scanamo.scan[Lemming](client)("lemmings").toList.size
+    *
+    * >>> LocalDynamoDB.withTable(client)("lemmings")('name -> S) {
+    * ...   Scanamo.putAll(client)("lemmings")(
+    * ...     (for { _ <- 0 until 100 } yield Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toList
+    * ...   )
+    * ...   Scanamo.scan[Lemming](client)("lemmings").toList.size
+    * ... }
     * 100
     * }}}
     */
@@ -181,14 +196,15 @@ object Scanamo {
     *
     * This can be as simple as looking up by a hash key where a range key also exists
     * {{{
+    * >>> case class Animal(species: String, number: Int)
+    *
     * >>> val client = LocalDynamoDB.client()
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-    * >>> val createTableResult = LocalDynamoDB.createTable(client)("animals")('species -> S, 'number -> N)
-    * >>> case class Animal(species: String, number: Int)
+    * >>> val tableResult = LocalDynamoDB.createTable(client)("animals")('species -> S, 'number -> N)
     *
     * >>> val r1 = Scanamo.put(client)("animals")(Animal("Wolf", 1))
     * >>> val r2 = for { i <- 1 to 3 } Scanamo.put(client)("animals")(Animal("Pig", i))
-    * * >>> Scanamo.query[Animal](client)("animals")(Query(KeyEquals('species, "Pig"))).toList
+    * >>> Scanamo.query[Animal](client)("animals")(Query(KeyEquals('species, "Pig"))).toList
     * List(Valid(Animal(Pig,1)), Valid(Animal(Pig,2)), Valid(Animal(Pig,3)))
     * }}}
     * or with some syntactic sugar
@@ -211,15 +227,14 @@ object Scanamo {
     * >>> Scanamo.query[Animal](client)("animals")('species -> "Pig" and 'number >= 2).toList
     * List(Valid(Animal(Pig,2)), Valid(Animal(Pig,3)))
     *
-    * >>> val transportTableResult = LocalDynamoDB.createTable(client)("transport")('mode -> S, 'line -> S)
     * >>> case class Transport(mode: String, line: String)
-    *
-    * >>> val lines = Scanamo.putAll(client)("transport")(List(
-    * ...   Transport("Underground", "Circle"),
-    * ...   Transport("Underground", "Metropolitan"),
-    * ...   Transport("Underground", "Central")))
-    *
-    * >>> Scanamo.query[Transport](client)("transport")('mode -> "Underground" and ('line beginsWith "C")).toList
+    * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
+    * ...   Scanamo.putAll(client)("transport")(List(
+    * ...     Transport("Underground", "Circle"),
+    * ...     Transport("Underground", "Metropolitan"),
+    * ...     Transport("Underground", "Central")))
+    * ...   Scanamo.query[Transport](client)("transport")('mode -> "Underground" and ('line beginsWith "C")).toList
+    * ... }
     * List(Valid(Transport(Underground,Central)), Valid(Transport(Underground,Circle)))
     * }}}
     */

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -1,9 +1,8 @@
 package com.gu.scanamo
 
 import cats.data.{Streaming, ValidatedNel}
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBAsync}
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model._
-import com.gu.scanamo.DynamoResultStream.{QueryResultStream, ScanResultStream}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -13,13 +12,21 @@ object ScanamoAsync {
   def exec[A](client: AmazonDynamoDBAsync)(op: ScanamoOps[A])(implicit ec: ExecutionContext) =
     op.foldMap(ScanamoInterpreters.future(client)(ec))
 
-  def put[T](client: AmazonDynamoDBAsync)(tableName: String)(item: T)(
-    implicit f: DynamoFormat[T], ec: ExecutionContext): Future[PutItemResult] =
+  def put[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(item: T)
+    (implicit ec: ExecutionContext): Future[PutItemResult] =
     exec(client)(ScanamoFree.put(tableName)(item))
 
-  def get[T](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
-    (implicit ft: DynamoFormat[T], ec: ExecutionContext): Future[Option[ValidatedNel[DynamoReadError, T]]] =
+  def putAll[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(items: List[T])
+    (implicit ec: ExecutionContext): Future[List[BatchWriteItemResult]] =
+    exec(client)(ScanamoFree.putAll(tableName)(items))
+
+  def get[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
+    (implicit ec: ExecutionContext): Future[Option[ValidatedNel[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.get[T](tableName)(key))
+
+  def getAll[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(keys: UniqueKeys[_])
+    (implicit ec: ExecutionContext): Future[List[ValidatedNel[DynamoReadError, T]]] =
+    exec(client)(ScanamoFree.getAll[T](tableName)(keys))
 
   def delete[T](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
     (implicit ec: ExecutionContext): Future[DeleteItemResult] =

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -1,0 +1,21 @@
+package com.gu.scanamo
+
+import cats.data.{Streaming, ValidatedNel}
+import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBAsync}
+import com.amazonaws.services.dynamodbv2.model._
+import com.gu.scanamo.DynamoResultStream.{QueryResultStream, ScanResultStream}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+object ScanamoAsync {
+  import cats.std.future._
+
+  def put[T](client: AmazonDynamoDBAsync)(tableName: String)(item: T)(
+    implicit f: DynamoFormat[T], ec: ExecutionContext): Future[PutItemResult] =
+    ScanamoFree.put(tableName)(item).foldMap(ScanamoInterpreters.future(client)(ec))
+
+  def get[T](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
+    (implicit ft: DynamoFormat[T], ec: ExecutionContext): Future[Option[ValidatedNel[DynamoReadError, T]]] =
+    ScanamoFree.get[T](tableName)(key).foldMap(ScanamoInterpreters.future(client)(ec))
+
+}

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -10,12 +10,19 @@ import scala.concurrent.{ExecutionContext, Future}
 object ScanamoAsync {
   import cats.std.future._
 
+  def exec[A](client: AmazonDynamoDBAsync)(op: ScanamoOps[A])(implicit ec: ExecutionContext) =
+    op.foldMap(ScanamoInterpreters.future(client)(ec))
+
   def put[T](client: AmazonDynamoDBAsync)(tableName: String)(item: T)(
     implicit f: DynamoFormat[T], ec: ExecutionContext): Future[PutItemResult] =
-    ScanamoFree.put(tableName)(item).foldMap(ScanamoInterpreters.future(client)(ec))
+    exec(client)(ScanamoFree.put(tableName)(item))
 
   def get[T](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
     (implicit ft: DynamoFormat[T], ec: ExecutionContext): Future[Option[ValidatedNel[DynamoReadError, T]]] =
-    ScanamoFree.get[T](tableName)(key).foldMap(ScanamoInterpreters.future(client)(ec))
+    exec(client)(ScanamoFree.get[T](tableName)(key))
+
+  def delete[T](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
+    (implicit ec: ExecutionContext): Future[DeleteItemResult] =
+    exec(client)(ScanamoFree.delete(tableName)(key))
 
 }

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -25,4 +25,12 @@ object ScanamoAsync {
     (implicit ec: ExecutionContext): Future[DeleteItemResult] =
     exec(client)(ScanamoFree.delete(tableName)(key))
 
+  def scan[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)
+    (implicit ec: ExecutionContext): Future[Streaming[ValidatedNel[DynamoReadError, T]]] =
+    exec(client)(ScanamoFree.scan(tableName))
+
+  def query[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(query: Query[_])
+    (implicit ec: ExecutionContext): Future[Streaming[ValidatedNel[DynamoReadError, T]]] =
+    exec(client)(ScanamoFree.query(tableName)(query))
+
 }

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -6,6 +6,13 @@ import com.amazonaws.services.dynamodbv2.model._
 
 import scala.concurrent.{ExecutionContext, Future}
 
+/**
+  * Provides the same interface as [[com.gu.scanamo.Scanamo]], except that it requires an implicit
+  * concurrent.ExecutionContext and returns a concurrent.Future
+  *
+  * Note that that com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient just uses an
+  * java.util.concurrent.ExecutorService to make calls asynchronously
+  */
 object ScanamoAsync {
   import cats.std.future._
 

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -30,8 +30,8 @@ object ScanamoFree {
       .map(read[T])
   }
 
-  def delete(client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_]): DeleteItemResult =
-    client.deleteItem(deleteRequest(tableName)(key))
+  def delete(tableName: String)(key: UniqueKey[_]): ScanamoOps[DeleteItemResult] =
+    ScanamoOps.delete(deleteRequest(tableName)(key))
 
   def scan[T](client: AmazonDynamoDB)(tableName: String)(implicit f: DynamoFormat[T]): Streaming[ValidatedNel[DynamoReadError, T]] = {
     ScanResultStream.stream[T](client)(

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -33,20 +33,11 @@ object ScanamoFree {
   def delete(tableName: String)(key: UniqueKey[_]): ScanamoOps[DeleteItemResult] =
     ScanamoOps.delete(deleteRequest(tableName)(key))
 
-  def scan[T](client: AmazonDynamoDB)(tableName: String)(implicit f: DynamoFormat[T]): Streaming[ValidatedNel[DynamoReadError, T]] = {
-    ScanResultStream.stream[T](client)(
-      new ScanRequest().withTableName(tableName)
-    )
-  }
+  def scan[T: DynamoFormat](tableName: String): ScanamoOps[Streaming[ValidatedNel[DynamoReadError, T]]] =
+    ScanResultStream.stream[T](new ScanRequest().withTableName(tableName))
 
-  def query[T](client: AmazonDynamoDB)(tableName: String)(keyCondition: Query[_])(
-    implicit f: DynamoFormat[T]
-  ) : Streaming[ValidatedNel[DynamoReadError, T]] = {
-
-    QueryResultStream.stream[T](client)(
-      queryRequest(tableName)(keyCondition)
-    )
-  }
+  def query[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[Streaming[ValidatedNel[DynamoReadError, T]]] =
+    QueryResultStream.stream[T](queryRequest(tableName)(query))
 
   def read[T](m: java.util.Map[String, AttributeValue])(implicit f: DynamoFormat[T]): ValidatedNel[DynamoReadError, T] =
     f.read(new AttributeValue().withM(m))

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -1,0 +1,53 @@
+package com.gu.scanamo
+
+import cats.data.{Streaming, ValidatedNel}
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.amazonaws.services.dynamodbv2.model._
+import com.gu.scanamo.DynamoResultStream.{QueryResultStream, ScanResultStream}
+
+object ScanamoFree {
+  import ScanamoRequest._
+
+  def put[T](tableName: String)(item: T)(implicit f: DynamoFormat[T]): ScanamoOps[PutItemResult] =
+    ScanamoOps.put(putRequest(tableName)(item))
+
+  def putAll[T](client: AmazonDynamoDB)(tableName: String)(items: List[T])(implicit f: DynamoFormat[T]): List[BatchWriteItemResult] =
+    (for {
+      batch <- items.grouped(25)
+    } yield client.batchWriteItem(batchPutRequest(tableName)(batch))).toList
+
+
+  def get[T](tableName: String)(key: UniqueKey[_])
+    (implicit ft: DynamoFormat[T]): ScanamoOps[Option[ValidatedNel[DynamoReadError, T]]] =
+    for {
+      res <- ScanamoOps.get(getRequest(tableName)(key))
+    } yield
+      Option(res.getItem).map(read[T])
+
+  def getAll[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(keys: UniqueKeys[_]): List[ValidatedNel[DynamoReadError, T]] = {
+    import collection.convert.decorateAsScala._
+    keys.sortByKeys(client.batchGetItem(batchGetRequest(tableName)(keys)).getResponses.get(tableName).asScala.toList)
+      .map(read[T])
+  }
+
+  def delete(client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_]): DeleteItemResult =
+    client.deleteItem(deleteRequest(tableName)(key))
+
+  def scan[T](client: AmazonDynamoDB)(tableName: String)(implicit f: DynamoFormat[T]): Streaming[ValidatedNel[DynamoReadError, T]] = {
+    ScanResultStream.stream[T](client)(
+      new ScanRequest().withTableName(tableName)
+    )
+  }
+
+  def query[T](client: AmazonDynamoDB)(tableName: String)(keyCondition: Query[_])(
+    implicit f: DynamoFormat[T]
+  ) : Streaming[ValidatedNel[DynamoReadError, T]] = {
+
+    QueryResultStream.stream[T](client)(
+      queryRequest(tableName)(keyCondition)
+    )
+  }
+
+  def read[T](m: java.util.Map[String, AttributeValue])(implicit f: DynamoFormat[T]): ValidatedNel[DynamoReadError, T] =
+    f.read(new AttributeValue().withM(m))
+}

--- a/src/main/scala/com/gu/scanamo/ScanamoOpsA.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoOpsA.scala
@@ -1,11 +1,10 @@
 package com.gu.scanamo
 
 import cats.{Id, ~>}
-import cats.data._
 import com.amazonaws.AmazonWebServiceRequest
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBAsync}
-import com.amazonaws.services.dynamodbv2.model.{GetItemRequest, GetItemResult, PutItemRequest, PutItemResult}
+import com.amazonaws.services.dynamodbv2.model._
 
 import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
@@ -13,14 +12,14 @@ import scala.util.{Failure, Success}
 sealed trait ScanamoOpsA[A]
 case class Put(req: PutItemRequest) extends ScanamoOpsA[PutItemResult]
 case class Get(req: GetItemRequest) extends ScanamoOpsA[GetItemResult]
+case class Delete(req: DeleteItemRequest) extends ScanamoOpsA[DeleteItemResult]
 
 object ScanamoOps {
   import cats.free.Free.liftF
 
   def put(req: PutItemRequest): ScanamoOps[PutItemResult] = liftF[ScanamoOpsA, PutItemResult](Put(req))
-  def get(req: GetItemRequest): ScanamoOps[GetItemResult] =
-    liftF[ScanamoOpsA, GetItemResult](Get(req))
-
+  def get(req: GetItemRequest): ScanamoOps[GetItemResult] = liftF[ScanamoOpsA, GetItemResult](Get(req))
+  def delete(req: DeleteItemRequest): ScanamoOps[DeleteItemResult] = liftF[ScanamoOpsA, DeleteItemResult](Delete(req))
 }
 
 object ScanamoInterpreters {
@@ -31,6 +30,8 @@ object ScanamoInterpreters {
         client.putItem(req)
       case Get(req) =>
         client.getItem(req)
+      case Delete(req) =>
+        client.deleteItem(req)
     }
   }
 
@@ -50,6 +51,8 @@ object ScanamoInterpreters {
         futureOf(client.putItemAsync, req)
       case Get(req) =>
         futureOf(client.getItemAsync, req)
+      case Delete(req) =>
+        futureOf(client.deleteItemAsync, req)
     }
   }
 }

--- a/src/main/scala/com/gu/scanamo/ScanamoOpsA.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoOpsA.scala
@@ -1,0 +1,56 @@
+package com.gu.scanamo
+
+import cats.{Id, ~>}
+import cats.data._
+import com.amazonaws.AmazonWebServiceRequest
+import com.amazonaws.handlers.AsyncHandler
+import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBAsync}
+import com.amazonaws.services.dynamodbv2.model.{GetItemRequest, GetItemResult, PutItemRequest, PutItemResult}
+
+import scala.concurrent.{ExecutionContext, Future, Promise}
+import scala.util.{Failure, Success}
+
+sealed trait ScanamoOpsA[A]
+case class Put(req: PutItemRequest) extends ScanamoOpsA[PutItemResult]
+case class Get(req: GetItemRequest) extends ScanamoOpsA[GetItemResult]
+
+object ScanamoOps {
+  import cats.free.Free.liftF
+
+  def put(req: PutItemRequest): ScanamoOps[PutItemResult] = liftF[ScanamoOpsA, PutItemResult](Put(req))
+  def get(req: GetItemRequest): ScanamoOps[GetItemResult] =
+    liftF[ScanamoOpsA, GetItemResult](Get(req))
+
+}
+
+object ScanamoInterpreters {
+
+  def id(client: AmazonDynamoDB) = new (ScanamoOpsA ~> Id) {
+    def apply[A](op: ScanamoOpsA[A]): Id[A] = op match {
+      case Put(req) =>
+        client.putItem(req)
+      case Get(req) =>
+        client.getItem(req)
+    }
+  }
+
+  def future(client: AmazonDynamoDBAsync)(implicit ec: ExecutionContext) = new (ScanamoOpsA ~> Future) {
+    private def futureOf[X <: AmazonWebServiceRequest, T](call: (X,AsyncHandler[X, T]) => java.util.concurrent.Future[T], req: X): Future[T] = {
+      val p = Promise[T]()
+      val h = new AsyncHandler[X, T] {
+        def onError(exception: Exception) { p.complete(Failure(exception)); () }
+        def onSuccess(request: X, result: T) { p.complete(Success(result)); () }
+      }
+      call(req, h)
+      p.future
+    }
+
+    override def apply[A](op: ScanamoOpsA[A]): Future[A] = op match {
+      case Put(req) =>
+        futureOf(client.putItemAsync, req)
+      case Get(req) =>
+        futureOf(client.getItemAsync, req)
+    }
+  }
+}
+

--- a/src/main/scala/com/gu/scanamo/ScanamoOpsA.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoOpsA.scala
@@ -10,9 +10,11 @@ import scala.concurrent.{ExecutionContext, Future, Promise}
 import scala.util.{Failure, Success}
 
 sealed trait ScanamoOpsA[A]
-case class Put(req: PutItemRequest) extends ScanamoOpsA[PutItemResult]
-case class Get(req: GetItemRequest) extends ScanamoOpsA[GetItemResult]
-case class Delete(req: DeleteItemRequest) extends ScanamoOpsA[DeleteItemResult]
+final case class Put(req: PutItemRequest) extends ScanamoOpsA[PutItemResult]
+final case class Get(req: GetItemRequest) extends ScanamoOpsA[GetItemResult]
+final case class Delete(req: DeleteItemRequest) extends ScanamoOpsA[DeleteItemResult]
+final case class Scan(req: ScanRequest) extends ScanamoOpsA[ScanResult]
+final case class QueryOp(req: QueryRequest) extends ScanamoOpsA[QueryResult]
 
 object ScanamoOps {
   import cats.free.Free.liftF
@@ -20,6 +22,8 @@ object ScanamoOps {
   def put(req: PutItemRequest): ScanamoOps[PutItemResult] = liftF[ScanamoOpsA, PutItemResult](Put(req))
   def get(req: GetItemRequest): ScanamoOps[GetItemResult] = liftF[ScanamoOpsA, GetItemResult](Get(req))
   def delete(req: DeleteItemRequest): ScanamoOps[DeleteItemResult] = liftF[ScanamoOpsA, DeleteItemResult](Delete(req))
+  def scan(req: ScanRequest): ScanamoOps[ScanResult] = liftF[ScanamoOpsA, ScanResult](Scan(req))
+  def query(req: QueryRequest): ScanamoOps[QueryResult] = liftF[ScanamoOpsA, QueryResult](QueryOp(req))
 }
 
 object ScanamoInterpreters {
@@ -32,6 +36,10 @@ object ScanamoInterpreters {
         client.getItem(req)
       case Delete(req) =>
         client.deleteItem(req)
+      case Scan(req) =>
+        client.scan(req)
+      case QueryOp(req) =>
+        client.query(req)
     }
   }
 
@@ -53,6 +61,10 @@ object ScanamoInterpreters {
         futureOf(client.getItemAsync, req)
       case Delete(req) =>
         futureOf(client.deleteItemAsync, req)
+      case Scan(req) =>
+        futureOf(client.scanAsync, req)
+      case QueryOp(req) =>
+        futureOf(client.queryAsync, req)
     }
   }
 }

--- a/src/main/scala/com/gu/scanamo/ScanamoOpsA.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoOpsA.scala
@@ -15,6 +15,8 @@ final case class Get(req: GetItemRequest) extends ScanamoOpsA[GetItemResult]
 final case class Delete(req: DeleteItemRequest) extends ScanamoOpsA[DeleteItemResult]
 final case class Scan(req: ScanRequest) extends ScanamoOpsA[ScanResult]
 final case class QueryOp(req: QueryRequest) extends ScanamoOpsA[QueryResult]
+final case class BatchWrite(req: BatchWriteItemRequest) extends ScanamoOpsA[BatchWriteItemResult]
+final case class BatchGet(req: BatchGetItemRequest) extends ScanamoOpsA[BatchGetItemResult]
 
 object ScanamoOps {
   import cats.free.Free.liftF
@@ -24,6 +26,10 @@ object ScanamoOps {
   def delete(req: DeleteItemRequest): ScanamoOps[DeleteItemResult] = liftF[ScanamoOpsA, DeleteItemResult](Delete(req))
   def scan(req: ScanRequest): ScanamoOps[ScanResult] = liftF[ScanamoOpsA, ScanResult](Scan(req))
   def query(req: QueryRequest): ScanamoOps[QueryResult] = liftF[ScanamoOpsA, QueryResult](QueryOp(req))
+  def batchWrite(req: BatchWriteItemRequest): ScanamoOps[BatchWriteItemResult] =
+    liftF[ScanamoOpsA, BatchWriteItemResult](BatchWrite(req))
+  def batchGet(req: BatchGetItemRequest): ScanamoOps[BatchGetItemResult] =
+    liftF[ScanamoOpsA, BatchGetItemResult](BatchGet(req))
 }
 
 object ScanamoInterpreters {
@@ -40,6 +46,10 @@ object ScanamoInterpreters {
         client.scan(req)
       case QueryOp(req) =>
         client.query(req)
+      case BatchWrite(req) =>
+        client.batchWriteItem(req)
+      case BatchGet(req) =>
+        client.batchGetItem(req)
     }
   }
 
@@ -65,6 +75,11 @@ object ScanamoInterpreters {
         futureOf(client.scanAsync, req)
       case QueryOp(req) =>
         futureOf(client.queryAsync, req)
+      // Overloading means we need explicit parameter types here
+      case BatchWrite(req) =>
+        futureOf(client.batchWriteItemAsync(_: BatchWriteItemRequest, _: AsyncHandler[BatchWriteItemRequest, BatchWriteItemResult]), req)
+      case BatchGet(req) =>
+        futureOf(client.batchGetItemAsync(_: BatchGetItemRequest, _: AsyncHandler[BatchGetItemRequest, BatchGetItemResult]), req)
     }
   }
 }

--- a/src/main/scala/com/gu/scanamo/package.scala
+++ b/src/main/scala/com/gu/scanamo/package.scala
@@ -1,6 +1,10 @@
 package com.gu
 
+import cats.free.Free
+
 package object scanamo {
+  type ScanamoOps[A] = Free[ScanamoOpsA, A]
+
   object syntax {
     implicit class SymbolKeyCondition(s: Symbol) {
       def <[V: DynamoFormat](v: V) = KeyIs(s, LT, v)

--- a/src/test/scala/com/gu/scanamo/LocalDynamoDB.scala
+++ b/src/test/scala/com/gu/scanamo/LocalDynamoDB.scala
@@ -30,4 +30,11 @@ object LocalDynamoDB {
     client.deleteTable(tableName)
     res
   }
+
+  def usingTable[T](client: AmazonDynamoDB)(tableName: String)(attributeDefinitions: (Symbol, ScalarAttributeType)*)(
+    thunk: => T
+  ): Unit = {
+    withTable(client)(tableName)(attributeDefinitions: _*)(thunk)
+    ()
+  }
 }

--- a/src/test/scala/com/gu/scanamo/LocalDynamoDB.scala
+++ b/src/test/scala/com/gu/scanamo/LocalDynamoDB.scala
@@ -1,13 +1,13 @@
 package com.gu.scanamo
 
+import com.amazonaws.services.dynamodbv2._
 import com.amazonaws.services.dynamodbv2.model._
-import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBClient, model}
 
-import collection.convert.decorateAsJava._
+import scala.collection.convert.decorateAsJava._
 
 object LocalDynamoDB {
   def client() = {
-    val c = new AmazonDynamoDBClient(new com.amazonaws.auth.BasicAWSCredentials("key", "secret"))
+    val c = new AmazonDynamoDBAsyncClient(new com.amazonaws.auth.BasicAWSCredentials("key", "secret"))
     c.setEndpoint("http://localhost:8000")
     c
   }

--- a/src/test/scala/com/gu/scanamo/LocalDynamoDB.scala
+++ b/src/test/scala/com/gu/scanamo/LocalDynamoDB.scala
@@ -21,4 +21,13 @@ object LocalDynamoDB {
       new ProvisionedThroughput(1L, 1L)
     )
   }
+
+  def withTable[T](client: AmazonDynamoDB)(tableName: String)(attributeDefinitions: (Symbol, ScalarAttributeType)*)(
+        thunk: => T
+  ): T = {
+    createTable(client)(tableName)(attributeDefinitions: _*)
+    val res = thunk
+    client.deleteTable(tableName)
+    res
+  }
 }

--- a/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -1,0 +1,64 @@
+package com.gu.scanamo
+
+import cats.data.Validated.Valid
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{Millis, Seconds, Span}
+import org.scalatest.{FunSpec, Matchers}
+
+class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
+  implicit val defaultPatience =
+    PatienceConfig(timeout = Span(2, Seconds), interval = Span(15, Millis))
+
+  val client = LocalDynamoDB.client()
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  it("should put asynchronously") {
+    import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    LocalDynamoDB.createTable(client)("asyncFarmers")('name -> S)
+    case class Farm(animals: List[String])
+    case class Farmer(name: String, age: Long, farm: Farm)
+
+    val putResult =
+      ScanamoAsync.put(client)("asyncFarmers")(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
+
+    import com.gu.scanamo.syntax._
+
+    val result = for {
+      _ <- putResult
+    } yield Scanamo.get[Farmer](client)("asyncFarmers")('name -> "McDonald")
+
+    result.futureValue should equal(Some(Valid(Farmer("McDonald",156,Farm(List("sheep", "cow"))))))
+
+    client.deleteTable("asyncFarmers")
+    ()
+  }
+
+  it("should get asynchronously") {
+    import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    LocalDynamoDB.createTable(client)("asyncFarmers")('name -> S)
+    case class Farm(animals: List[String])
+    case class Farmer(name: String, age: Long, farm: Farm)
+
+    val putResult = Scanamo.put(client)("asyncFarmers")(Farmer("Maggot", 75L, Farm(List("dog"))))
+
+    ScanamoAsync.get[Farmer](client)("asyncFarmers")(UniqueKey(KeyEquals('name, "Maggot")))
+      .futureValue should equal(Some(Valid(Farmer("Maggot",75,Farm(List("dog"))))))
+
+    import com.gu.scanamo.syntax._
+
+    ScanamoAsync.get[Farmer](client)("asyncFarmers")('name -> "Maggot")
+      .futureValue should equal(Some(Valid(Farmer("Maggot",75,Farm(List("dog"))))))
+
+    val createTableResult = LocalDynamoDB.createTable(client)("asyncEngines")('name -> S, 'number -> N)
+
+    case class Engine(name: String, number: Int)
+
+    val thomas = Scanamo.put(client)("asyncEngines")(Engine("Thomas", 1))
+
+    ScanamoAsync.get[Engine](client)("asyncEngines")('name -> "Thomas" and 'number -> 1)
+      .futureValue should equal(Some(Valid(Engine("Thomas",1))))
+
+    client.deleteTable("asyncFarmers")
+    ()
+  }
+}

--- a/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -15,7 +15,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
 
   it("should put asynchronously") {
     LocalDynamoDB.createTable(client)("asyncFarmers")('name -> S)
-    case class Farm(animals: List[String])
+    case class Farm(asyncAnimals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
     val putResult =
@@ -35,7 +35,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
 
   it("should get asynchronously") {
     LocalDynamoDB.createTable(client)("asyncFarmers")('name -> S)
-    case class Farm(animals: List[String])
+    case class Farm(asyncAnimals: List[String])
     case class Farmer(name: String, age: Long, farm: Farm)
 
     val putResult = Scanamo.put(client)("asyncFarmers")(Farmer("Maggot", 75L, Farm(List("dog"))))
@@ -64,7 +64,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
   it("should delete asynchronously") {
     LocalDynamoDB.createTable(client)("asyncFarmers")('name -> S)
 
-    case class Farm(animals: List[String])
+    case class Farm(asyncAnimals: List[String])
 
     case class Farmer(name: String, age: Long, farm: Farm)
 
@@ -79,6 +79,79 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
     maybeFarmer.futureValue should equal(None)
 
     client.deleteTable("asyncFarmers")
+    ()
+  }
+  
+  it("should scan asynchronously") {
+    LocalDynamoDB.createTable(client)("asyncBears")('name -> S)
+
+    case class Bear(name: String, favouriteFood: String)
+
+    val r1 = Scanamo.put(client)("asyncBears")(Bear("Pooh", "honey"))
+
+    val r2 = Scanamo.put(client)("asyncBears")(Bear("Yogi", "picnic baskets"))
+
+    ScanamoAsync.scan[Bear](client)("asyncBears").futureValue.toList should equal(
+      List(Valid(Bear("Pooh","honey")), Valid(Bear("Yogi","picnic baskets")))
+    )
+
+    client.deleteTable("asyncBears")
+
+    LocalDynamoDB.createTable(client)("asyncLemmings")('name -> S)
+
+    case class Lemming(name: String, stuff: String)
+
+    val lemmingResults = Scanamo.putAll(client)("asyncLemmings")(
+      (for { _ <- 0 until 100 } yield Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toList
+    )
+
+    ScanamoAsync.scan[Lemming](client)("asyncLemmings").futureValue.toList.size should equal(100)
+
+    client.deleteTable("asyncLemmings")
+    ()
+  }
+
+  it("should query asynchronously") {
+    LocalDynamoDB.createTable(client)("asyncAnimals")('species -> S, 'number -> N)
+
+    case class Animal(species: String, number: Int)
+
+    val r1 = Scanamo.put(client)("asyncAnimals")(Animal("Wolf", 1))
+
+    val r2 = for { i <- 1 to 3 } Scanamo.put(client)("asyncAnimals")(Animal("Pig", i))
+
+    import com.gu.scanamo.syntax._
+
+    ScanamoAsync.query[Animal](client)("asyncAnimals")('species -> "Pig").futureValue.toList should equal(
+      List(Valid(Animal("Pig",1)), Valid(Animal("Pig",2)), Valid(Animal("Pig",3))))
+
+    ScanamoAsync.query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number < 3).futureValue.toList should equal(
+      List(Valid(Animal("Pig",1)), Valid(Animal("Pig",2))))
+
+    ScanamoAsync.query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number > 1).futureValue.toList should equal(
+      List(Valid(Animal("Pig",2)), Valid(Animal("Pig",3))))
+
+    ScanamoAsync.query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number <= 2).futureValue.toList should equal(
+      List(Valid(Animal("Pig",1)), Valid(Animal("Pig",2))))
+
+    ScanamoAsync.query[Animal](client)("asyncAnimals")('species -> "Pig" and 'number >= 2).futureValue.toList should equal(
+      List(Valid(Animal("Pig",2)), Valid(Animal("Pig",3))))
+
+    client.deleteTable("asyncAnimals")
+
+    LocalDynamoDB.createTable(client)("asyncTransport")('mode -> S, 'line -> S)
+
+    case class Transport(mode: String, line: String)
+
+    val lines = Scanamo.putAll(client)("asyncTransport")(List(
+      Transport("Underground", "Circle"),
+      Transport("Underground", "Metropolitan"),
+      Transport("Underground", "Central")))
+
+    ScanamoAsync.query[Transport](client)("asyncTransport")('mode -> "Underground" and ('line beginsWith "C")).futureValue.toList should equal(
+      List(Valid(Transport("Underground","Central")), Valid(Transport("Underground","Circle"))))
+
+    client.deleteTable("asyncTransport")
     ()
   }
 }


### PR DESCRIPTION
This adds `ScanamoAsync` which has the same interface as `Scanamo` except that it requires an `ExecutionContext` in scope and returns a `Future`.

I've avoided duplication by abstracting over the precise execution behaviour using the [Free Monad](http://typelevel.org/cats/tut/freemonad.html). This also means that if you want a purely functional interface you can use the Free structure directly and push its interpretation to the end of the world.