### PR TITLE
Upgrade to cats 0.6.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ scalaVersion := "2.11.8"
 libraryDependencies ++= Seq(
 	"com.amazonaws" % "aws-java-sdk-dynamodb" % "1.10.69",
   "com.chuusai" %% "shapeless" % "2.3.0",
-  "org.typelevel" %% "cats" % "0.5.0",
+  "org.typelevel" %% "cats" % "0.6.0",
 
   "com.github.mpilquist" %% "simulacrum" % "0.7.0",
 

--- a/src/main/scala/com/gu/scanamo/DynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/DynamoFormat.scala
@@ -21,9 +21,9 @@ import scala.reflect.ClassTag
   * DynamoDB's `AttributeValue`
   *
   * {{{
-  * >>> val mapF = DynamoFormat[Map[String, List[Int]]]
-  * >>> mapF.read(mapF.write(Map("foo" -> List(1, 2, 3), "bar" -> List(3, 2, 1))))
-  * Right(Map(foo -> List(1, 2, 3), bar -> List(3, 2, 1)))
+  * >>> val listOptionFormat = DynamoFormat[List[Option[Int]]]
+  * >>> listOptionFormat.read(listOptionFormat.write(List(Some(1), None, Some(3))))
+  * Right(List(Some(1), None, Some(3)))
   * }}}
   *
   * Also supports automatic derivation for case classes


### PR DESCRIPTION
Also remove test that depended on the order in `Map`'s toString, which isn't determined and for some reason changed on the upgrade.