### PR TITLE
Use Sets for bulk operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ scala> def temptWithGum(child: LuckyWinner): LuckyWinner = child match {
 scala> val luckyWinners = Table[LuckyWinner]("winners")
 scala> val operations = for {
      |      _               <- luckyWinners.putAll(
-     |                           List(LuckyWinner("Violet", "human"), LuckyWinner("Augustus", "human"), LuckyWinner("Charlie", "human")))
+     |                           Set(LuckyWinner("Violet", "human"), LuckyWinner("Augustus", "human"), LuckyWinner("Charlie", "human")))
      |      winners         <- luckyWinners.scan()
      |      winnerList      =  winners.flatMap(_.toOption).toList
      |      temptedWinners  =  winnerList.map(temptWithGum)
-     |      _               <- luckyWinners.putAll(temptedWinners)
+     |      _               <- luckyWinners.putAll(temptedWinners.toSet)
      |      results         <- luckyWinners.getAll('name -> List("Charlie", "Violet"))
      | } yield results
      
@@ -105,7 +105,7 @@ scala> val transportTableResult = LocalDynamoDB.createTable(client)("transports"
 scala> case class Transport(mode: String, line: String)
 scala> val transportTable = Table[Transport]("transports")
 scala> val operations = for {
-     |   _ <- transportTable.putAll(List(
+     |   _ <- transportTable.putAll(Set(
      |          Transport("Underground", "Circle"),
      |          Transport("Underground", "Metropolitan"),
      |          Transport("Underground", "Central")
@@ -160,7 +160,7 @@ scala> val client = LocalDynamoDB.client()
 scala> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
 scala> LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")('mode -> S, 'line -> S)('colour -> S) {
      |   val operations = for {
-     |     _ <- transport.putAll(List(
+     |     _ <- transport.putAll(Set(
      |       Transport("Underground", "Circle", "Yellow"),
      |       Transport("Underground", "Metropolitan", "Maroon"),
      |       Transport("Underground", "Central", "Red")))
@@ -190,7 +190,7 @@ scala> case class Farm(animals: List[String])
 scala> case class Farmer(name: String, age: Long, farm: Farm)
 scala> val farmTable = Table[Farmer]("farm")
 scala> val ops = for {
-     |   _ <- farmTable.putAll(List(
+     |   _ <- farmTable.putAll(Set(
      |          Farmer("Boggis", 43L, Farm(List("chicken"))), 
      |          Farmer("Bunce", 52L, Farm(List("goose"))), 
      |          Farmer("Bean", 55L, Farm(List("turkey")))

--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ scala> val operations = for {
      |      winnerList      =  winners.flatMap(_.toOption).toList
      |      temptedWinners  =  winnerList.map(temptWithGum)
      |      _               <- luckyWinners.putAll(temptedWinners.toSet)
-     |      results         <- luckyWinners.getAll('name -> List("Charlie", "Violet"))
+     |      results         <- luckyWinners.getAll('name -> Set("Charlie", "Violet"))
      | } yield results
      
-scala> Scanamo.exec(client)(operations).toList
-res1: List[cats.data.Xor[error.DynamoReadError, LuckyWinner]] = List(Right(LuckyWinner(Charlie,human)), Right(LuckyWinner(Violet,blueberry)))
+scala> Scanamo.exec(client)(operations)
+res1: Set[cats.data.Xor[error.DynamoReadError, LuckyWinner]] = Set(Right(LuckyWinner(Charlie,human)), Right(LuckyWinner(Violet,blueberry)))
 ```
 
 Note that when using `Table` no operations are actually executed against DynamoDB until `exec` is called. 

--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -48,13 +48,13 @@ object Scanamo {
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> LocalDynamoDB.withTable(client)("rabbits")('name -> S) {
     * ...   Scanamo.putAll(client)("rabbits")((
-    * ...   for { _ <- 0 until 100 } yield Rabbit(util.Random.nextString(500))).toList)
+    * ...   for { _ <- 0 until 100 } yield Rabbit(util.Random.nextString(500))).toSet)
     * ...   Scanamo.scan[Rabbit](client)("rabbits").size
     * ... }
     * 100
     * }}}
     */
-  def putAll[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(items: List[T]): List[BatchWriteItemResult] =
+  def putAll[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(items: Set[T]): List[BatchWriteItemResult] =
     exec(client)(ScanamoFree.putAll(tableName)(items))
 
   /**
@@ -109,7 +109,7 @@ object Scanamo {
     *
     * >>> import com.gu.scanamo.query._
     * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
-    * ...   Scanamo.putAll(client)("farmers")(List(
+    * ...   Scanamo.putAll(client)("farmers")(Set(
     * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
     * ...   ))
     * ...   Scanamo.getAll[Farmer](client)("farmers")(UniqueKeys(KeyList('name, List("Boggis", "Bean"))))
@@ -120,7 +120,7 @@ object Scanamo {
     * {{{
     * >>> import com.gu.scanamo.syntax._
     * >>> LocalDynamoDB.withTable(client)("farmers")('name -> S) {
-    * ...   Scanamo.putAll(client)("farmers")(List(
+    * ...   Scanamo.putAll(client)("farmers")(Set(
     * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
     * ...   ))
     * ...   Scanamo.getAll[Farmer](client)("farmers")('name -> List("Boggis", "Bean"))
@@ -132,7 +132,7 @@ object Scanamo {
     * >>> case class Doctor(actor: String, regeneration: Int)
     * >>> LocalDynamoDB.withTable(client)("doctors")('actor -> S, 'regeneration -> N) {
     * ...   Scanamo.putAll(client)("doctors")(
-    * ...     List(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
+    * ...     Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
     * ...   Scanamo.getAll[Doctor](client)("doctors")(('actor and 'regeneration) -> List("McCoy" -> 9, "Ecclestone" -> 11))
     * ... }
     * List(Right(Doctor(McCoy,9)), Right(Doctor(Ecclestone,11)))
@@ -212,7 +212,7 @@ object Scanamo {
     *
     * >>> LocalDynamoDB.withTable(client)("lemmings")('name -> S) {
     * ...   Scanamo.putAll(client)("lemmings")(
-    * ...     (for { _ <- 0 until 100 } yield Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toList
+    * ...     (for { _ <- 0 until 100 } yield Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet
     * ...   )
     * ...   Scanamo.scan[Lemming](client)("lemmings").size
     * ... }
@@ -326,7 +326,7 @@ object Scanamo {
     *
     * >>> case class Transport(mode: String, line: String)
     * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
-    * ...   Scanamo.putAll(client)("transport")(List(
+    * ...   Scanamo.putAll(client)("transport")(Set(
     * ...     Transport("Underground", "Circle"),
     * ...     Transport("Underground", "Metropolitan"),
     * ...     Transport("Underground", "Central")))
@@ -357,7 +357,7 @@ object Scanamo {
     *
     * >>> case class Transport(mode: String, line: String)
     * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
-    * ...   Scanamo.putAll(client)("transport")(List(
+    * ...   Scanamo.putAll(client)("transport")(Set(
     * ...     Transport("Underground", "Circle"),
     * ...     Transport("Underground", "Metropolitan"),
     * ...     Transport("Underground", "Central")))
@@ -380,7 +380,7 @@ object Scanamo {
     * >>> import com.gu.scanamo.syntax._
     *
     * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")('mode -> S, 'line -> S)('colour -> S) {
-    * ...   Scanamo.putAll(client)("transport")(List(
+    * ...   Scanamo.putAll(client)("transport")(Set(
     * ...     Transport("Underground", "Circle", "Yellow"),
     * ...     Transport("Underground", "Metropolitan", "Magenta"),
     * ...     Transport("Underground", "Central", "Red")))
@@ -405,7 +405,7 @@ object Scanamo {
     * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")(
     * ...   'mode -> S, 'line -> S)('mode -> S, 'colour -> S
     * ... ) {
-    * ...   Scanamo.putAll(client)("transport")(List(
+    * ...   Scanamo.putAll(client)("transport")(Set(
     * ...     Transport("Underground", "Circle", "Yellow"),
     * ...     Transport("Underground", "Metropolitan", "Magenta"),
     * ...     Transport("Underground", "Central", "Red"),

--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -112,9 +112,9 @@ object Scanamo {
     * ...   Scanamo.putAll(client)("farmers")(Set(
     * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
     * ...   ))
-    * ...   Scanamo.getAll[Farmer](client)("farmers")(UniqueKeys(KeyList('name, List("Boggis", "Bean"))))
+    * ...   Scanamo.getAll[Farmer](client)("farmers")(UniqueKeys(KeyList('name, Set("Boggis", "Bean"))))
     * ... }
-    * List(Right(Farmer(Boggis,43,Farm(List(chicken)))), Right(Farmer(Bean,55,Farm(List(turkey)))))
+    * Set(Right(Farmer(Bean,55,Farm(List(turkey)))), Right(Farmer(Boggis,43,Farm(List(chicken)))))
     * }}}
     * or with some added syntactic sugar:
     * {{{
@@ -123,9 +123,9 @@ object Scanamo {
     * ...   Scanamo.putAll(client)("farmers")(Set(
     * ...     Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
     * ...   ))
-    * ...   Scanamo.getAll[Farmer](client)("farmers")('name -> List("Boggis", "Bean"))
+    * ...   Scanamo.getAll[Farmer](client)("farmers")('name -> Set("Boggis", "Bean"))
     * ... }
-    * List(Right(Farmer(Boggis,43,Farm(List(chicken)))), Right(Farmer(Bean,55,Farm(List(turkey)))))
+    * Set(Right(Farmer(Bean,55,Farm(List(turkey)))), Right(Farmer(Boggis,43,Farm(List(chicken)))))
     * }}}
     * You can also retrieve items from a table with both a hash and range key
     * {{{
@@ -133,13 +133,13 @@ object Scanamo {
     * >>> LocalDynamoDB.withTable(client)("doctors")('actor -> S, 'regeneration -> N) {
     * ...   Scanamo.putAll(client)("doctors")(
     * ...     Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
-    * ...   Scanamo.getAll[Doctor](client)("doctors")(('actor and 'regeneration) -> List("McCoy" -> 9, "Ecclestone" -> 11))
+    * ...   Scanamo.getAll[Doctor](client)("doctors")(('actor and 'regeneration) -> Set("McCoy" -> 9, "Ecclestone" -> 11))
     * ... }
-    * List(Right(Doctor(McCoy,9)), Right(Doctor(Ecclestone,11)))
+    * Set(Right(Doctor(McCoy,9)), Right(Doctor(Ecclestone,11)))
     * }}}
     */
   def getAll[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(keys: UniqueKeys[_])
-    : List[Xor[DynamoReadError, T]] =
+    : Set[Xor[DynamoReadError, T]] =
     exec(client)(ScanamoFree.getAll(tableName)(keys))
 
 

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -27,7 +27,7 @@ object ScanamoAsync {
     (implicit ec: ExecutionContext): Future[PutItemResult] =
     exec(client)(ScanamoFree.put(tableName)(item))
 
-  def putAll[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(items: List[T])
+  def putAll[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(items: Set[T])
     (implicit ec: ExecutionContext): Future[List[BatchWriteItemResult]] =
     exec(client)(ScanamoFree.putAll(tableName)(items))
 

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -36,7 +36,7 @@ object ScanamoAsync {
     exec(client)(ScanamoFree.get[T](tableName)(key))
 
   def getAll[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(keys: UniqueKeys[_])
-    (implicit ec: ExecutionContext): Future[List[Xor[DynamoReadError, T]]] =
+    (implicit ec: ExecutionContext): Future[Set[Xor[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.getAll[T](tableName)(keys))
 
   def delete[T](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -21,7 +21,7 @@ object ScanamoFree {
   def put[T](tableName: String)(item: T)(implicit f: DynamoFormat[T]): ScanamoOps[PutItemResult] =
     ScanamoOps.put(putRequest(tableName)(item))
 
-  def putAll[T: DynamoFormat](tableName: String)(items: List[T]): ScanamoOps[List[BatchWriteItemResult]] =
+  def putAll[T: DynamoFormat](tableName: String)(items: Set[T]): ScanamoOps[List[BatchWriteItemResult]] =
     items.grouped(25).toList.traverseU(batch =>
       ScanamoOps.batchWrite(batchPutRequest(tableName)(batch)))
 

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -32,12 +32,12 @@ object ScanamoFree {
     } yield
       Option(res.getItem).map(read[T])
 
-  def getAll[T: DynamoFormat](tableName: String)(keys: UniqueKeys[_]): ScanamoOps[List[Xor[DynamoReadError, T]]] = {
+  def getAll[T: DynamoFormat](tableName: String)(keys: UniqueKeys[_]): ScanamoOps[Set[Xor[DynamoReadError, T]]] = {
     import collection.convert.decorateAsScala._
     for {
       res <- ScanamoOps.batchGet(batchGetRequest(tableName)(keys))
     } yield
-      keys.sortByKeys(res.getResponses.get(tableName).asScala.toList).map(read[T])
+      res.getResponses.get(tableName).asScala.toSet.map(read[T])
   }
 
   def delete(tableName: String)(key: UniqueKey[_]): ScanamoOps[DeleteItemResult] =

--- a/src/main/scala/com/gu/scanamo/ScanamoRequest.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoRequest.scala
@@ -23,8 +23,8 @@ private object Requests {
   def putRequest[T](tableName: String)(item: T)(implicit f: DynamoFormat[T]): ScanamoPutRequest =
     ScanamoPutRequest(tableName, f.write(item).getM, None)
 
-  def batchPutRequest[T](tableName: String)(items: List[T])(implicit f: DynamoFormat[T]): BatchWriteItemRequest =
-    new BatchWriteItemRequest().withRequestItems(Map(tableName -> items.map(i =>
+  def batchPutRequest[T](tableName: String)(items: Set[T])(implicit f: DynamoFormat[T]): BatchWriteItemRequest =
+    new BatchWriteItemRequest().withRequestItems(Map(tableName -> items.toList.map(i =>
       new WriteRequest().withPutRequest(new PutRequest().withItem(f.write(i).getM))
     ).asJava).asJava)
 

--- a/src/main/scala/com/gu/scanamo/Table.scala
+++ b/src/main/scala/com/gu/scanamo/Table.scala
@@ -19,7 +19,7 @@ import com.gu.scanamo.update.UpdateExpression
   * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
   * ...   import com.gu.scanamo.syntax._
   * ...   val operations = for {
-  * ...     _ <- transport.putAll(List(
+  * ...     _ <- transport.putAll(Set(
   * ...       Transport("Underground", "Circle"),
   * ...       Transport("Underground", "Metropolitan"),
   * ...       Transport("Underground", "Central")))
@@ -33,7 +33,7 @@ import com.gu.scanamo.update.UpdateExpression
 case class Table[V: DynamoFormat](name: String) {
 
   def put(v: V) = ScanamoFree.put(name)(v)
-  def putAll(vs: List[V]) = ScanamoFree.putAll(name)(vs)
+  def putAll(vs: Set[V]) = ScanamoFree.putAll(name)(vs)
   def get(key: UniqueKey[_]) = ScanamoFree.get[V](name)(key)
   def getAll(keys: UniqueKeys[_]) = ScanamoFree.getAll[V](name)(keys)
   def delete(key: UniqueKey[_]) = ScanamoFree.delete(name)(key)
@@ -51,7 +51,7 @@ case class Table[V: DynamoFormat](name: String) {
     *
     * >>> LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")('mode -> S, 'line -> S)('colour -> S) {
     * ...   val operations = for {
-    * ...     _ <- transport.putAll(List(
+    * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle", "Yellow"),
     * ...       Transport("Underground", "Metropolitan", "Magenta"),
     * ...       Transport("Underground", "Central", "Red")))
@@ -159,7 +159,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
     * ...   import com.gu.scanamo.syntax._
     * ...   val operations = for {
-    * ...     _ <- transport.putAll(List(
+    * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle"),
     * ...       Transport("Underground", "Metropolitan"),
     * ...       Transport("Underground", "Central")))
@@ -200,7 +200,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val lettersTable = Table[Letter]("letters")
     * >>> LocalDynamoDB.withTable(client)("letters")('roman -> S) {
     * ...   val ops = for {
-    * ...     _ <- lettersTable.putAll(List(Letter("a", "alpha"), Letter("b", "beta"), Letter("c", "gammon")))
+    * ...     _ <- lettersTable.putAll(Set(Letter("a", "alpha"), Letter("b", "beta"), Letter("c", "gammon")))
     * ...     _ <- lettersTable.given('greek beginsWith "ale").put(Letter("a", "aleph"))
     * ...     _ <- lettersTable.given('greek beginsWith "gam").put(Letter("c", "gamma"))
     * ...     letters <- lettersTable.scan()
@@ -214,7 +214,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val turnipsTable = Table[Turnip]("turnips")
     * >>> LocalDynamoDB.withTable(client)("turnips")('size -> N) {
     * ...   val ops = for {
-    * ...     _ <- turnipsTable.putAll(List(Turnip(1, None), Turnip(1000, None)))
+    * ...     _ <- turnipsTable.putAll(Set(Turnip(1, None), Turnip(1000, None)))
     * ...     initialTurnips <- turnipsTable.scan()
     * ...     _ <- initialTurnips.flatMap(_.toOption).traverse(t =>
     * ...       turnipsTable.given('size > 500).put(t.copy(description = Some("Big turnip in the country."))))
@@ -232,7 +232,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val thingTable = Table[Thing]("things")
     * >>> LocalDynamoDB.withTable(client)("things")('a -> S) {
     * ...   val ops = for {
-    * ...     _ <- thingTable.putAll(List(Thing("a", None), Thing("b", Some(1)), Thing("c", None)))
+    * ...     _ <- thingTable.putAll(Set(Thing("a", None), Thing("b", Some(1)), Thing("c", None)))
     * ...     _ <- thingTable.given(attributeExists('maybe)).put(Thing("a", Some(2)))
     * ...     _ <- thingTable.given(attributeExists('maybe)).put(Thing("b", Some(3)))
     * ...     _ <- thingTable.given(Not(attributeExists('maybe))).put(Thing("c", Some(42)))
@@ -251,7 +251,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val compoundTable = Table[Compound]("compounds")
     * >>> LocalDynamoDB.withTable(client)("compounds")('a -> S) {
     * ...   val ops = for {
-    * ...     _ <- compoundTable.putAll(List(Compound("alpha", None), Compound("beta", Some(1)), Compound("gamma", None)))
+    * ...     _ <- compoundTable.putAll(Set(Compound("alpha", None), Compound("beta", Some(1)), Compound("gamma", None)))
     * ...     _ <- compoundTable.given(attributeExists('maybe) and 'a -> "alpha").put(Compound("alpha", Some(2)))
     * ...     _ <- compoundTable.given(attributeExists('maybe) and 'a -> "beta").put(Compound("beta", Some(3)))
     * ...     _ <- compoundTable.given(Condition('a -> "gamma") and attributeExists('maybe)).put(Compound("gamma", Some(42)))
@@ -269,7 +269,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val choicesTable = Table[Choice]("choices")
     * >>> LocalDynamoDB.withTable(client)("choices")('number -> N) {
     * ...   val ops = for {
-    * ...     _ <- choicesTable.putAll(List(Choice(1, "cake"), Choice(2, "crumble"), Choice(3, "custard")))
+    * ...     _ <- choicesTable.putAll(Set(Choice(1, "cake"), Choice(2, "crumble"), Choice(3, "custard")))
     * ...     _ <- choicesTable.given(Condition('description -> "cake") or 'description -> "death").put(Choice(1, "victoria sponge"))
     * ...     _ <- choicesTable.given(Condition('description -> "cake") or 'description -> "death").put(Choice(2, "victoria sponge"))
     * ...     choices <- choicesTable.scan()
@@ -286,7 +286,7 @@ case class Table[V: DynamoFormat](name: String) {
     * >>> val gremlinsTable = Table[Gremlin]("gremlins")
     * >>> LocalDynamoDB.withTable(client)("gremlins")('number -> N) {
     * ...   val ops = for {
-    * ...     _ <- gremlinsTable.putAll(List(Gremlin(1, false, true), Gremlin(2, true, false)))
+    * ...     _ <- gremlinsTable.putAll(Set(Gremlin(1, false, true), Gremlin(2, true, false)))
     * ...     _ <- gremlinsTable.given('wet -> true).delete('number -> 1)
     * ...     _ <- gremlinsTable.given('wet -> true).delete('number -> 2)
     * ...     remainingGremlins <- gremlinsTable.scan()
@@ -301,7 +301,7 @@ case class Table[V: DynamoFormat](name: String) {
     * {{{
     * >>> LocalDynamoDB.withTable(client)("gremlins")('number -> N) {
     * ...   val ops = for {
-    * ...     _ <- gremlinsTable.putAll(List(Gremlin(1, false, true), Gremlin(2, true, true)))
+    * ...     _ <- gremlinsTable.putAll(Set(Gremlin(1, false, true), Gremlin(2, true, true)))
     * ...     _ <- gremlinsTable.given('wet -> true).update('number -> 1, set('friendly -> false))
     * ...     _ <- gremlinsTable.given('wet -> true).update('number -> 2, set('friendly -> false))
     * ...     remainingGremlins <- gremlinsTable.scan()
@@ -329,7 +329,7 @@ private[scanamo] case class Index[V: DynamoFormat](tableName: String, indexName:
     * ...   'mode -> S, 'line -> S)('mode -> S, 'colour -> S
     * ... ) {
     * ...   val operations = for {
-    * ...     _ <- transport.putAll(List(
+    * ...     _ <- transport.putAll(Set(
     * ...       Transport("Underground", "Circle", "Yellow"),
     * ...       Transport("Underground", "Metropolitan", "Magenta"),
     * ...       Transport("Underground", "Central", "Red"),

--- a/src/main/scala/com/gu/scanamo/package.scala
+++ b/src/main/scala/com/gu/scanamo/package.scala
@@ -26,10 +26,10 @@ package object scanamo {
 
     implicit def toUniqueKey[T: UniqueKeyCondition](t: T) = UniqueKey(t)
 
-    implicit def symbolListTupleToUniqueKeys[V: DynamoFormat](pair: (Symbol, List[V])) =
+    implicit def symbolListTupleToUniqueKeys[V: DynamoFormat](pair: (Symbol, Set[V])) =
       UniqueKeys(KeyList(pair._1, pair._2))
 
-    implicit def toMultipleKeyList[H: DynamoFormat, R: DynamoFormat](pair: (HashAndRangeKeyNames, List[(H, R)])) =
+    implicit def toMultipleKeyList[H: DynamoFormat, R: DynamoFormat](pair: (HashAndRangeKeyNames, Set[(H, R)])) =
       UniqueKeys(MultipleKeyList(pair._1.hash -> pair._1.range, pair._2))
 
     implicit def symbolTupleToQuery[V: DynamoFormat](pair: (Symbol, V)) =

--- a/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -266,14 +266,14 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
       ))
 
       ScanamoAsync.getAll[Farmer](client)("asyncFarmers")(
-        UniqueKeys(KeyList('name, List("Boggis", "Bean")))
+        UniqueKeys(KeyList('name, Set("Boggis", "Bean")))
       ).futureValue should equal(
-        List(Right(Farmer("Boggis", 43, Farm(List("chicken")))), Right(Farmer("Bean", 55, Farm(List("turkey"))))))
+        Set(Right(Farmer("Boggis", 43, Farm(List("chicken")))), Right(Farmer("Bean", 55, Farm(List("turkey"))))))
 
       import com.gu.scanamo.syntax._
 
-      ScanamoAsync.getAll[Farmer](client)("asyncFarmers")('name -> List("Boggis", "Bean")).futureValue should equal(
-        List(Right(Farmer("Boggis", 43, Farm(List("chicken")))), Right(Farmer("Bean", 55, Farm(List("turkey"))))))
+      ScanamoAsync.getAll[Farmer](client)("asyncFarmers")('name -> Set("Boggis", "Bean")).futureValue should equal(
+        Set(Right(Farmer("Boggis", 43, Farm(List("chicken")))), Right(Farmer("Bean", 55, Farm(List("turkey"))))))
     }
 
     LocalDynamoDB.usingTable(client)("asyncDoctors")('actor -> S, 'regeneration -> N) {
@@ -284,9 +284,9 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
 
       import com.gu.scanamo.syntax._
       ScanamoAsync.getAll[Doctor](client)("asyncDoctors")(
-        ('actor and 'regeneration) -> List("McCoy" -> 9, "Ecclestone" -> 11)
+        ('actor and 'regeneration) -> Set("McCoy" -> 9, "Ecclestone" -> 11)
       ).futureValue should equal(
-        List(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
+        Set(Right(Doctor("McCoy", 9)), Right(Doctor("Ecclestone", 11))))
 
     }
   }

--- a/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -101,7 +101,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
       import com.gu.scanamo.syntax._
 
       val ops = for {
-        _ <- forecasts.putAll(List(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
+        _ <- forecasts.putAll(Set(Forecast("London", "Rain", None), Forecast("Birmingham", "Sun", None)))
         _ <- forecasts.given('weather -> "Rain").update('location -> "London", set('equipment -> Some("umbrella")))
         _ <- forecasts.given('weather -> "Rain").update('location -> "Birmingham", set('equipment -> Some("umbrella")))
         results <- forecasts.scan()
@@ -130,7 +130,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
       case class Lemming(name: String, stuff: String)
 
       Scanamo.putAll(client)("asyncLemmings")(
-        (for {_ <- 0 until 100} yield Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toList
+        (for {_ <- 0 until 100} yield Lemming(util.Random.nextString(500), util.Random.nextString(5000))).toSet
       )
 
       ScanamoAsync.scan[Lemming](client)("asyncLemmings").futureValue.toList.size should equal(100)
@@ -194,7 +194,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
 
       import com.gu.scanamo.syntax._
 
-      Scanamo.putAll(client)("asyncTransport")(List(
+      Scanamo.putAll(client)("asyncTransport")(Set(
         Transport("Underground", "Circle"),
         Transport("Underground", "Metropolitan"),
         Transport("Underground", "Central")))
@@ -210,7 +210,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
     case class Transport(mode: String, line: String)
 
     LocalDynamoDB.withTable(client)("transport")('mode -> S, 'line -> S) {
-      Scanamo.putAll(client)("transport")(List(
+      Scanamo.putAll(client)("transport")(Set(
         Transport("Underground", "Circle"),
         Transport("Underground", "Metropolitan"),
         Transport("Underground", "Central")))
@@ -227,7 +227,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
     LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-index")(
       'mode -> S, 'line -> S)('mode -> S, 'colour -> S
     ) {
-      Scanamo.putAll(client)("transport")(List(
+      Scanamo.putAll(client)("transport")(Set(
         Transport("Underground", "Circle", "Yellow"),
         Transport("Underground", "Metropolitan", "Magenta"),
         Transport("Underground", "Central", "Red"),
@@ -247,7 +247,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
       val result = for {
         _ <- ScanamoAsync.putAll(client)("asyncRabbits")((
           for {_ <- 0 until 100} yield Rabbit(util.Random.nextString(500))
-          ).toList)
+          ).toSet)
       } yield Scanamo.scan[Rabbit](client)("asyncRabbits")
 
       result.futureValue.toList.size should equal(100)
@@ -261,7 +261,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
       case class Farm(animals: List[String])
       case class Farmer(name: String, age: Long, farm: Farm)
 
-      Scanamo.putAll(client)("asyncFarmers")(List(
+      Scanamo.putAll(client)("asyncFarmers")(Set(
         Farmer("Boggis", 43L, Farm(List("chicken"))), Farmer("Bunce", 52L, Farm(List("goose"))), Farmer("Bean", 55L, Farm(List("turkey")))
       ))
 
@@ -280,7 +280,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
       case class Doctor(actor: String, regeneration: Int)
 
       Scanamo.putAll(client)("asyncDoctors")(
-        List(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
+        Set(Doctor("McCoy", 9), Doctor("Ecclestone", 10), Doctor("Ecclestone", 11)))
 
       import com.gu.scanamo.syntax._
       ScanamoAsync.getAll[Doctor](client)("asyncDoctors")(
@@ -320,7 +320,7 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
 
     LocalDynamoDB.usingTable(client)("gremlins")('number -> N) {
       val ops = for {
-        _ <- gremlinsTable.putAll(List(Gremlin(1, false), Gremlin(2, true)))
+        _ <- gremlinsTable.putAll(Set(Gremlin(1, false), Gremlin(2, true)))
         _ <- gremlinsTable.given('wet -> true).delete('number -> 1)
         _ <- gremlinsTable.given('wet -> true).delete('number -> 2)
         remainingGremlins <- gremlinsTable.scan()

--- a/src/test/scala/com/gu/scanamo/ScanamoTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoTest.scala
@@ -9,7 +9,7 @@ class ScanamoTest extends org.scalatest.FunSpec with org.scalatest.Matchers {
 
     case class Large(name: String, number: Int, stuff: String)
     Scanamo.putAll(client)("large-query")(
-      (for { i <- 0 until 100 } yield Large("Harry", i, util.Random.nextString(5000))).toList
+      (for { i <- 0 until 100 } yield Large("Harry", i, util.Random.nextString(5000))).toSet
     )
     Scanamo.put(client)("large-query")(Large("George", 1, "x"))
     import syntax._


### PR DESCRIPTION
As noted in #50, DynamoDB assumes that bulk operations are performed on a Set. This doesn't ensure the set is of the form expected by DynamoDB, i.e. it doesn't ensure the hash/range key combination are unique, but I think it better conveys the intent.

cc @lindseydew @emma-p 