### PR TITLE
Update to Cats 0.7.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,19 +5,21 @@ scalaVersion := "2.11.8"
 
 crossScalaVersions := Seq(scalaVersion.value, "2.10.6")
 
+resolvers += Resolver.sonatypeRepo("snapshots")
+
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.8",
-  "com.chuusai" %% "shapeless" % "2.3.1",
-  "org.typelevel" %% "cats" % "0.6.0",
+  "com.chuusai" %% "shapeless" % "2.3.2",
+  "org.typelevel" %% "cats-free" % "0.7.0",
 
-  "com.github.mpilquist" %% "simulacrum" % "0.7.0",
+  "com.github.mpilquist" %% "simulacrum" % "0.8.0",
 
   // Use Joda for custom conversion example
   "org.joda" % "joda-convert" % "1.8.1" % Provided,
   "joda-time" % "joda-time" % "2.9.4" % Test,
 
   "org.scalatest" %% "scalatest" % "2.2.6" % Test,
-  "org.scalacheck" %% "scalacheck" % "1.12.4" % Test
+  "org.scalacheck" %% "scalacheck" % "1.12.5" % Test
 )
 // for simulacrum
 addCompilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.11
+sbt.version=0.13.12

--- a/src/main/scala/com/gu/scanamo/DerivedDynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/DerivedDynamoFormat.scala
@@ -36,7 +36,7 @@ trait DerivedDynamoFormat {
         val validatedValue = possibleValue.getOrElse(Xor.left[DynamoReadError, V](MissingProperty))
 
         def withPropertyError(x: Xor[DynamoReadError, V]): Validated[InvalidPropertiesError, V] =
-          x.leftMap(e => InvalidPropertiesError(NonEmptyList(PropertyReadError(fieldName, e)))).toValidated
+          x.leftMap(e => InvalidPropertiesError(NonEmptyList(PropertyReadError(fieldName, e), Nil))).toValidated
 
         val head: Validated[InvalidPropertiesError, FieldType[K, V]] = withPropertyError(validatedValue).map(field[K](_))
         val tail = tailFormat.value.read(av)

--- a/src/main/scala/com/gu/scanamo/DynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/DynamoFormat.scala
@@ -2,9 +2,9 @@ package com.gu.scanamo
 
 import cats.NotNull
 import cats.data._
-import cats.std.list._
-import cats.std.map._
-import cats.std.vector._
+import cats.instances.list._
+import cats.instances.map._
+import cats.instances.vector._
 import cats.syntax.traverse._
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.gu.scanamo.error._
@@ -39,7 +39,7 @@ import java.nio.ByteBuffer
   * >>> case class Developer(name: String, age: String, problems: Int)
   * >>> val invalid = DynamoFormat[Farmer].read(DynamoFormat[Developer].write(Developer("Alice", "none of your business", 99)))
   * >>> invalid
-  * Left(InvalidPropertiesError(OneAnd(PropertyReadError(age,NoPropertyOfType(N,{S: none of your business,})),List(PropertyReadError(farm,MissingProperty)))))
+  * Left(InvalidPropertiesError(NonEmptyList(PropertyReadError(age,NoPropertyOfType(N,{S: none of your business,})), PropertyReadError(farm,MissingProperty))))
   *
   * >>> invalid.leftMap(cats.Show[error.DynamoReadError].show)
   * Left('age': not of type: 'N' was '{S: none of your business,}', 'farm': missing)

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -18,7 +18,7 @@ import scala.concurrent.{ExecutionContext, Future}
   * java.util.concurrent.ExecutorService to make calls asynchronously
   */
 object ScanamoAsync {
-  import cats.std.future._
+  import cats.instances.future._
 
   def exec[A](client: AmazonDynamoDBAsync)(op: ScanamoOps[A])(implicit ec: ExecutionContext) =
     op.foldMap(ScanamoInterpreters.future(client)(ec))

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -11,7 +11,7 @@ import com.gu.scanamo.update.UpdateExpression
 
 object ScanamoFree {
 
-  import cats.std.list._
+  import cats.instances.list._
   import cats.syntax.traverse._
   import collection.convert.decorateAsJava._
 

--- a/src/main/scala/com/gu/scanamo/error/DynamoReadError.scala
+++ b/src/main/scala/com/gu/scanamo/error/DynamoReadError.scala
@@ -2,7 +2,7 @@ package com.gu.scanamo.error
 
 import cats.{Semigroup, Show}
 import cats.data.NonEmptyList
-import cats.std.list._
+import cats.instances.list._
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
 
 sealed abstract class DynamoReadError
@@ -26,7 +26,7 @@ object DynamoReadError {
   }
 
   def describe(d: DynamoReadError): String =  d match {
-    case InvalidPropertiesError(problems) => problems.unwrap.map(p => s"'${p.name}': ${describe(p.problem)}").mkString(", ")
+    case InvalidPropertiesError(problems) => problems.toList.map(p => s"'${p.name}': ${describe(p.problem)}").mkString(", ")
     case NoPropertyOfType(propertyType, actual) => s"not of type: '$propertyType' was '$actual'"
     case TypeCoercionError(e) => s"could not be converted to desired type: $e"
     case MissingProperty => "missing"

--- a/src/main/scala/com/gu/scanamo/update/UpdateExpression.scala
+++ b/src/main/scala/com/gu/scanamo/update/UpdateExpression.scala
@@ -1,7 +1,7 @@
 package com.gu.scanamo.update
 
 import cats.kernel.Semigroup
-import cats.kernel.std.MapMonoid
+import cats.kernel.instances.MapMonoid
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
 import com.gu.scanamo.DynamoFormat
 import simulacrum.typeclass


### PR DESCRIPTION
This updates the library to the Cats 0.7.0 snapshot, and shouldn't be merged until 0.7.0 is published. It also depends on [this Cats change](https://github.com/typelevel/cats/pull/1261), which is merged but not yet in the snapshot, so you'll have to publish the snapshot locally if you want to run the tests right now (they do pass if you do that).

I've also changed the cats dependency from `cats` to `cats-free`, since the `cats` module is [only meant to be a pedagogical convenience](https://github.com/typelevel/cats/issues/1181#issuecomment-231589592) (it pulls in test dependencies, etc.), and shouldn't be used in production.