### PR TITLE
Add explicit query and scan methods

### DIFF
--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -188,9 +188,8 @@ object Scanamo {
     exec(client)(ScanamoFree.update(tableName)(key)(expression))
 
   /**
-    * Lazily scans a table
+    * Scans all elements of a table
     *
-    * Does not cache results by default
     * {{{
     * >>> case class Bear(name: String, favouriteFood: String)
     *


### PR DESCRIPTION
Added to Table, Index and their equivalents with a limit.  This is not strictly necessary as if you import the Scanamo syntax it will augment the classes appropriately, but they don't show up in Scaladoc and people were confused, so this adds them explicitly.