### PR TITLE
Add a map method to DynamoFormat

### DIFF
--- a/src/main/scala/com/gu/scanamo/DynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/DynamoFormat.scala
@@ -52,7 +52,7 @@ import java.nio.ByteBuffer
   * Right(LargelyOptional(None,Some(X)))
   * }}}
   *
-  * Custom formats can often be most easily defined using [[DynamoFormat.coercedXmap]], [[DynamoFormat.xmap]] or [[DynamoFormat.map]]
+  * Custom formats can often be most easily defined using [[DynamoFormat.coercedXmap]], [[DynamoFormat.xmap]] or [[DynamoFormat.iso]]
   */
 @typeclass trait DynamoFormat[T] {
   def read(av: AttributeValue): Xor[DynamoReadError, T]
@@ -86,16 +86,13 @@ object DynamoFormat extends DerivedDynamoFormat {
     *
     * >>> case class UserId(value: String)
     *
-    * >>> implicit val userIdFormat = DynamoFormat.map[UserId, String](
-    * ...   UserId.apply
-    * ... )(
-    * ...   _.value
-    * ... )
+    * >>> implicit val userIdFormat =
+    * ...   DynamoFormat.iso[UserId, String](UserId.apply)(_.value)
     * >>> DynamoFormat[UserId].read(new AttributeValue().withS("Eric"))
     * Right(UserId(Eric))
     * }}}
     */
-  def map[A, B](r: B => A)(w: A => B)(implicit f: DynamoFormat[B]) = new DynamoFormat[A] {
+  def iso[A, B](r: B => A)(w: A => B)(implicit f: DynamoFormat[B]) = new DynamoFormat[A] {
     override def read(item: AttributeValue): Xor[DynamoReadError, A] = f.read(item).map(r)
     override def write(t: A): AttributeValue = f.write(w(t))
   }


### PR DESCRIPTION
This is a purely selfish PR. Given:

```
case class RoleId(value: String) extends AnyVal
```

it means I can write:

```
implicit val dynamoFormat: DynamoFormat[RoleId] =
  DynamoFormat.map[RoleId, String](RoleId.apply)(_.value)
```

instead of:

```
implicit val dynamoFormat: DynamoFormat[RoleId] =
  DynamoFormat.xmap[RoleId, String](value => Xor.right(RoleId(value)))(_.value)
```