### PR TITLE
Provide better errors when can't derive a DynamoFormat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,6 +14,10 @@ libraryDependencies ++= Seq(
 
   "com.github.mpilquist" %% "simulacrum" % "0.8.0",
 
+  "org.typelevel" %% "macro-compat" % "1.1.1",
+  "org.scala-lang" % "scala-compiler" % scalaVersion.value % "provided",
+  compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full),
+
   // Use Joda for custom conversion example
   "org.joda" % "joda-convert" % "1.8.1" % Provided,
   "joda-time" % "joda-time" % "2.9.4" % Test,


### PR DESCRIPTION
Add a universal macro at the bottom of the priority tree that reports the specific missing DynamoFormat, not just the top-level case class.

This is a REPL session showing the behaviour:

![image](https://cloud.githubusercontent.com/assets/68329/18665246/2953fd50-7f1e-11e6-9112-bedae2990aac.png)

Previously you would just get that last line.
