### PR TITLE
Read DynamoDB NULL as None

### DIFF
--- a/src/main/scala/com/gu/scanamo/DynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/DynamoFormat.scala
@@ -310,11 +310,14 @@ object DynamoFormat extends DerivedDynamoFormat {
     * prop> (o: Option[Long]) =>
     *     | DynamoFormat[Option[Long]].read(DynamoFormat[Option[Long]].write(o)) ==
     *     |   cats.data.Xor.right(o)
+    *
+    * >>> DynamoFormat[Option[Long]].read(new com.amazonaws.services.dynamodbv2.model.AttributeValue().withNULL(true))
+    * Right(None)
     * }}}
     */
   implicit def optionFormat[T](implicit f: DynamoFormat[T]) = new DynamoFormat[Option[T]] {
     def read(av: AttributeValue): Xor[DynamoReadError, Option[T]] = {
-      Option(av).map(f.read(_).map(Some(_)))
+      Option(av).filter(x => !Boolean.unbox(x.isNULL)).map(f.read(_).map(Some(_)))
         .getOrElse(Xor.right(Option.empty[T]))
     }
 


### PR DESCRIPTION
This is complicated by the fact that the Java client's API returns a boxed Boolean which is `null` if no NULL value is set. Using an explicit `Boolean.unbox`, so that `null` evaluates to `false`is the least clumsy workaround I can find for this.