### PR TITLE
Return the new value after an update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,5 @@ cache:
 before_cache:
   - find $HOME/.sbt -name "*.lock" -type f -delete -print
   - find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete -print
-script: "sbt clean coverage +test"
+script: "sbt clean coverage test"
 after_success: "sbt coverageReport coveralls"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,8 +5,7 @@
  * default `DynamoFormat` instance for `Short`
  * upgrade to Cats 0.7.0 (@travisbrown)
  * added `scan` and `query` methods explicitly to `Table` and `Index`
- * publish for Scala 2.10 as well as 2.11
- 
+
 Breaking change:
 
  * Bulk operations(`putAll` and `getAll`) now take a `Set` rather than `List`, which

--- a/README.md
+++ b/README.md
@@ -133,12 +133,11 @@ scala> case class Team(name: String, goals: Int, scorers: List[String], mascot: 
 scala> val teamTable = Table[Team]("teams")
 scala> val operations = for {
      |   _ <- teamTable.put(Team("Watford", 1, List("Blissett"), Some("Harry the Hornet")))
-     |   _ <- teamTable.update('name -> "Watford", set('goals -> 2) and append('scorers -> "Barnes") and remove('mascot))
-     |   watford <- teamTable.get('name -> "Watford")
-     | } yield watford
+     |   updated <- teamTable.update('name -> "Watford", set('goals -> 2) and append('scorers -> "Barnes") and remove('mascot))
+     | } yield updated
      
 scala> Scanamo.exec(client)(operations)
-res1: Option[cats.data.Xor[error.DynamoReadError, Team]] = Some(Right(Team(Watford,2,List(Blissett, Barnes),None)))
+res1: cats.data.Xor[error.DynamoReadError, Team] = Right(Team(Watford,2,List(Blissett, Barnes),None))
 ``` 
 
 ### Using Indexes

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,6 @@ organization := "com.gu"
 
 scalaVersion := "2.11.8"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.10.6")
-
 resolvers += Resolver.sonatypeRepo("snapshots")
 
 libraryDependencies ++= Seq(

--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -184,8 +184,8 @@ object Scanamo {
     * List(Right(Forecast(London,Sun)))
     * }}}
     */
-  def update[T: UpdateExpression](client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_], expression: T): UpdateItemResult =
-    exec(client)(ScanamoFree.update(tableName)(key)(expression))
+  def update[V: DynamoFormat, U: UpdateExpression](client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_], expression: U): Xor[DynamoReadError, V] =
+    exec(client)(ScanamoFree.update[V, U](tableName)(key)(expression))
 
   /**
     * Scans all elements of a table

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -43,9 +43,10 @@ object ScanamoAsync {
     (implicit ec: ExecutionContext): Future[DeleteItemResult] =
     exec(client)(ScanamoFree.delete(tableName)(key))
 
-  def update[T: UpdateExpression](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_], expression: T)
-    (implicit ec: ExecutionContext): Future[UpdateItemResult] =
-    exec(client)(ScanamoFree.update(tableName)(key)(expression))
+  def update[V: DynamoFormat, U: UpdateExpression](client: AmazonDynamoDBAsync)(tableName: String)(
+    key: UniqueKey[_], expression: U)(implicit ec: ExecutionContext
+  ): Future[Xor[DynamoReadError,V]] =
+    exec(client)(ScanamoFree.update[V, U](tableName)(key)(expression))
 
   def scan[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)
     (implicit ec: ExecutionContext): Future[List[Xor[DynamoReadError, T]]] =

--- a/src/main/scala/com/gu/scanamo/error/DynamoReadError.scala
+++ b/src/main/scala/com/gu/scanamo/error/DynamoReadError.scala
@@ -3,9 +3,12 @@ package com.gu.scanamo.error
 import cats.{Semigroup, Show}
 import cats.data.NonEmptyList
 import cats.instances.list._
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import com.amazonaws.services.dynamodbv2.model.{AttributeValue, ConditionalCheckFailedException}
 
-sealed abstract class DynamoReadError
+sealed abstract class ScanamoError
+final case class ConditionNotMet(e: ConditionalCheckFailedException) extends ScanamoError
+
+sealed abstract class DynamoReadError extends ScanamoError
 final case class NoPropertyOfType(propertyType: String, actual: AttributeValue) extends DynamoReadError
 final case class TypeCoercionError(t: Throwable) extends DynamoReadError
 final case object MissingProperty extends DynamoReadError

--- a/src/main/scala/com/gu/scanamo/ops/ScanamoInterpreters.scala
+++ b/src/main/scala/com/gu/scanamo/ops/ScanamoInterpreters.scala
@@ -38,6 +38,7 @@ object ScanamoInterpreters {
         .withUpdateExpression(req.updateExpression)
         .withExpressionAttributeNames(req.attributeNames.asJava)
         .withExpressionAttributeValues(req.attributeValues.asJava)
+        .withReturnValues(ReturnValue.ALL_NEW)
     )((r, c) =>
       c.attributeValues.foldLeft(
         r.withConditionExpression(c.expression).withExpressionAttributeNames(


### PR DESCRIPTION
This an attempt to address #61 and I'd love to hear whether this is actually a solution or not.

My presumption is that it's much more likely that someone will be interested in the state after the update than before, so this changes the default behaviour to return that and uses the `DynamoFormat` to then transform that back into the case class associated with the table.

My belief is that this will address most use cases without significantly complicating the interface, but can be convinced that's not the case.