### PR TITLE
`Xor` -> `Either`

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,11 @@ scala> case class Farmer(name: String, age: Long, farm: Farm)
 
 scala> val putResult = Scanamo.put(client)("farmer")(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
 scala> Scanamo.get[Farmer](client)("farmer")('name -> "McDonald")
-res1: Option[cats.data.Xor[error.DynamoReadError, Farmer]] = Some(Right(Farmer(McDonald,156,Farm(List(sheep, cow)))))
+res1: Option[Either[error.DynamoReadError, Farmer]] = Some(Right(Farmer(McDonald,156,Farm(List(sheep, cow)))))
 ```
 
-The `Xor` represents the possibility that an item might exist, but not be parseable into the given 
-type, in this case `Farmer`. For more information on `Xor`, see the 
-[Cats documentation](http://typelevel.org/cats/tut/xor.html).
+The `Either` represents the possibility that an item might exist, but not be parsable into the given
+type, in this case `Farmer`.
 
 Like all the examples in this README and the Scaladoc, this creates a table, so that it 
 can be checked using [sbt-doctest](https://github.com/tkawachi/sbt-doctest), but the same 
@@ -64,6 +63,7 @@ abstraction to reduce noise when defining multiple operations against the same t
 ```scala
 scala> import com.gu.scanamo._
 scala> import com.gu.scanamo.syntax._
+scala> import cats.syntax.either._
 
 scala> val client = LocalDynamoDB.client()
 scala> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
@@ -86,7 +86,7 @@ scala> val operations = for {
      | } yield results
      
 scala> Scanamo.exec(client)(operations)
-res1: Set[cats.data.Xor[error.DynamoReadError, LuckyWinner]] = Set(Right(LuckyWinner(Charlie,human)), Right(LuckyWinner(Violet,blueberry)))
+res1: Set[Either[error.DynamoReadError, LuckyWinner]] = Set(Right(LuckyWinner(Charlie,human)), Right(LuckyWinner(Violet,blueberry)))
 ```
 
 Note that when using `Table` no operations are actually executed against DynamoDB until `exec` is called. 
@@ -114,7 +114,7 @@ scala> val operations = for {
      | } yield tubesStartingWithC.toList
      
 scala> Scanamo.exec(client)(operations)
-res1: List[cats.data.Xor[error.DynamoReadError, Transport]] = List(Right(Transport(Underground,Central)), Right(Transport(Underground,Circle)))
+res1: List[Either[error.DynamoReadError, Transport]] = List(Right(Transport(Underground,Central)), Right(Transport(Underground,Circle)))
 ```
 
 ### Updating
@@ -137,8 +137,8 @@ scala> val operations = for {
      | } yield updated
      
 scala> Scanamo.exec(client)(operations)
-res1: cats.data.Xor[error.DynamoReadError, Team] = Right(Team(Watford,2,List(Blissett, Barnes),None))
-``` 
+res1: Either[error.DynamoReadError, Team] = Right(Team(Watford,2,List(Blissett, Barnes),None))
+```
 
 ### Using Indexes
 
@@ -167,7 +167,7 @@ scala> LocalDynamoDB.withTableWithSecondaryIndex(client)("transport", "colour-in
      |   } yield maroonLine.toList
      |   Scanamo.exec(client)(operations)
      | }
-res0: List[cats.data.Xor[error.DynamoReadError, Transport]] = List(Right(Transport(Underground,Metropolitan,Maroon)))
+res0: List[Either[error.DynamoReadError, Transport]] = List(Right(Transport(Underground,Metropolitan,Maroon)))
 ```
 
 ### Non-blocking requests
@@ -198,7 +198,7 @@ scala> val ops = for {
      | } yield bunce
      
 scala> concurrent.Await.result(ScanamoAsync.exec(client)(ops), 5.seconds)
-res1: Option[cats.data.Xor[error.DynamoReadError, Farmer]] = Some(Right(Farmer(Bunce,52,Farm(List(goose)))))
+res1: Option[Either[error.DynamoReadError, Farmer]] = Some(Right(Farmer(Bunce,52,Farm(List(goose)))))
 ```
 
 ### Custom Formats
@@ -233,7 +233,7 @@ scala> val operations = for {
      | } yield results
  
 scala> Scanamo.exec(client)(operations).toList
-res1: List[cats.data.Xor[error.DynamoReadError, Foo]] = List(Right(Foo(1970-01-01T00:00:00.000Z)))
+res1: List[Either[error.DynamoReadError, Foo]] = List(Right(Foo(1970-01-01T00:00:00.000Z)))
 ```
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.8",
   "com.chuusai" %% "shapeless" % "2.3.2",
-  "org.typelevel" %% "cats-free" % "0.7.0",
+  "org.typelevel" %% "cats-free" % "0.7.2",
 
   "com.github.mpilquist" %% "simulacrum" % "0.8.0",
 

--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -1,6 +1,5 @@
 package com.gu.scanamo
 
-import cats.data.Xor
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import com.amazonaws.services.dynamodbv2.model.{BatchWriteItemResult, DeleteItemResult, PutItemResult, UpdateItemResult}
 import com.gu.scanamo.error.DynamoReadError
@@ -92,7 +91,7 @@ object Scanamo {
     * }}}
     */
   def get[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_])
-    : Option[Xor[DynamoReadError, T]] =
+    : Option[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.get[T](tableName)(key))
 
   /**
@@ -139,7 +138,7 @@ object Scanamo {
     * }}}
     */
   def getAll[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(keys: UniqueKeys[_])
-    : Set[Xor[DynamoReadError, T]] =
+    : Set[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.getAll(tableName)(keys))
 
 
@@ -184,7 +183,7 @@ object Scanamo {
     * List(Right(Forecast(London,Sun)))
     * }}}
     */
-  def update[V: DynamoFormat, U: UpdateExpression](client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_], expression: U): Xor[DynamoReadError, V] =
+  def update[V: DynamoFormat, U: UpdateExpression](client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_], expression: U): Either[DynamoReadError, V] =
     exec(client)(ScanamoFree.update[V, U](tableName)(key)(expression))
 
   /**
@@ -219,7 +218,7 @@ object Scanamo {
     * }}}
     */
   def scan[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)
-    : List[Xor[DynamoReadError, T]] =
+    : List[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.scan(tableName))
 
   /**
@@ -240,7 +239,7 @@ object Scanamo {
     * }}}
     */
   def scanWithLimit[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String, limit: Int)
-    : List[Xor[DynamoReadError, T]] =
+    : List[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.scanWithLimit(tableName, limit))
 
   /**
@@ -261,7 +260,7 @@ object Scanamo {
     * }}}
     */
   def scanIndex[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String, indexName: String)
-  : List[Xor[DynamoReadError, T]] =
+  : List[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.scanIndex(tableName, indexName))
 
   /**
@@ -283,7 +282,7 @@ object Scanamo {
     * }}}
     */
   def scanIndexWithLimit[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String, indexName: String, limit: Int)
-  : List[Xor[DynamoReadError, T]] =
+  : List[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.scanIndexWithLimit(tableName, indexName, limit))
 
   /**
@@ -343,7 +342,7 @@ object Scanamo {
     * }}}
     */
   def query[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(query: Query[_])
-    : List[Xor[DynamoReadError, T]] =
+    : List[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.query(tableName)(query))
 
   /**
@@ -366,7 +365,7 @@ object Scanamo {
     * }}}
     */
   def queryWithLimit[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(query: Query[_], limit: Int)
-  : List[Xor[DynamoReadError, T]] =
+  : List[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.queryWithLimit(tableName)(query, limit))
 
   /**
@@ -389,7 +388,7 @@ object Scanamo {
     * }}}
     */
   def queryIndex[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String, indexName: String)(query: Query[_])
-  : List[Xor[DynamoReadError, T]] =
+  : List[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.queryIndex(tableName, indexName)(query))
 
   /**
@@ -417,6 +416,6 @@ object Scanamo {
     * }}}
     */
   def queryIndexWithLimit[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String, indexName: String)(query: Query[_], limit: Int)
-  : List[Xor[DynamoReadError, T]] =
+  : List[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.queryIndexWithLimit(tableName, indexName)(query, limit))
 }

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -1,6 +1,5 @@
 package com.gu.scanamo
 
-import cats.data.Xor
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsync
 import com.amazonaws.services.dynamodbv2.model.{BatchWriteItemResult, DeleteItemResult, PutItemResult, UpdateItemResult}
 import com.gu.scanamo.error.DynamoReadError
@@ -32,11 +31,11 @@ object ScanamoAsync {
     exec(client)(ScanamoFree.putAll(tableName)(items))
 
   def get[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
-    (implicit ec: ExecutionContext): Future[Option[Xor[DynamoReadError, T]]] =
+    (implicit ec: ExecutionContext): Future[Option[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.get[T](tableName)(key))
 
   def getAll[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(keys: UniqueKeys[_])
-    (implicit ec: ExecutionContext): Future[Set[Xor[DynamoReadError, T]]] =
+    (implicit ec: ExecutionContext): Future[Set[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.getAll[T](tableName)(keys))
 
   def delete[T](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
@@ -45,38 +44,38 @@ object ScanamoAsync {
 
   def update[V: DynamoFormat, U: UpdateExpression](client: AmazonDynamoDBAsync)(tableName: String)(
     key: UniqueKey[_], expression: U)(implicit ec: ExecutionContext
-  ): Future[Xor[DynamoReadError,V]] =
+  ): Future[Either[DynamoReadError,V]] =
     exec(client)(ScanamoFree.update[V, U](tableName)(key)(expression))
 
   def scan[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)
-    (implicit ec: ExecutionContext): Future[List[Xor[DynamoReadError, T]]] =
+    (implicit ec: ExecutionContext): Future[List[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.scan(tableName))
 
   def scanWithLimit[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String, limit: Int)
-    (implicit ec: ExecutionContext): Future[List[Xor[DynamoReadError, T]]] =
+    (implicit ec: ExecutionContext): Future[List[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.scanWithLimit(tableName, limit))
 
   def scanIndex[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String, indexName: String)
-    (implicit ec: ExecutionContext): Future[List[Xor[DynamoReadError, T]]] =
+    (implicit ec: ExecutionContext): Future[List[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.scanIndex(tableName, indexName))
 
   def scanIndexWithLimit[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String, indexName: String, limit: Int)
-    (implicit ec: ExecutionContext): Future[List[Xor[DynamoReadError, T]]] =
+    (implicit ec: ExecutionContext): Future[List[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.scanIndexWithLimit(tableName, indexName, limit))
 
   def query[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(query: Query[_])
-    (implicit ec: ExecutionContext): Future[List[Xor[DynamoReadError, T]]] =
+    (implicit ec: ExecutionContext): Future[List[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.query(tableName)(query))
 
   def queryWithLimit[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(query: Query[_], limit: Int)
-    (implicit ec: ExecutionContext): Future[List[Xor[DynamoReadError, T]]] =
+    (implicit ec: ExecutionContext): Future[List[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.queryWithLimit(tableName)(query, limit))
 
   def queryIndex[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String, indexName: String)(query: Query[_])
-    (implicit ec: ExecutionContext): Future[List[Xor[DynamoReadError, T]]] =
+    (implicit ec: ExecutionContext): Future[List[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.queryIndex(tableName, indexName)(query))
 
   def queryIndexWithLimit[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String, indexName: String)(
-    query: Query[_], limit: Int)(implicit ec: ExecutionContext): Future[List[Xor[DynamoReadError, T]]] =
+    query: Query[_], limit: Int)(implicit ec: ExecutionContext): Future[List[Either[DynamoReadError, T]]] =
     exec(client)(ScanamoFree.queryIndexWithLimit(tableName, indexName)(query, limit))
 }

--- a/src/main/scala/com/gu/scanamo/ops/ScanamoInterpreters.scala
+++ b/src/main/scala/com/gu/scanamo/ops/ScanamoInterpreters.scala
@@ -1,7 +1,7 @@
 package com.gu.scanamo.ops
 
 import cats._
-import cats.data.Xor
+import cats.syntax.either._
 import com.amazonaws.AmazonWebServiceRequest
 import com.amazonaws.handlers.AsyncHandler
 import com.amazonaws.services.dynamodbv2.{AmazonDynamoDB, AmazonDynamoDBAsync}
@@ -52,7 +52,7 @@ object ScanamoInterpreters {
       case Put(req) =>
         client.putItem(javaPutRequest(req))
       case ConditionalPut(req) =>
-        Xor.catchOnly[ConditionalCheckFailedException] {
+        Either.catchOnly[ConditionalCheckFailedException] {
           client.putItem(javaPutRequest(req))
         }
       case Get(req) =>
@@ -60,7 +60,7 @@ object ScanamoInterpreters {
       case Delete(req) =>
         client.deleteItem(javaDeleteRequest(req))
       case ConditionalDelete(req) =>
-        Xor.catchOnly[ConditionalCheckFailedException] {
+        Either.catchOnly[ConditionalCheckFailedException] {
           client.deleteItem(javaDeleteRequest(req))
         }
       case Scan(req) =>
@@ -74,7 +74,7 @@ object ScanamoInterpreters {
       case Update(req) =>
         client.updateItem(javaUpdateRequest(req))
       case ConditionalUpdate(req) =>
-        Xor.catchOnly[ConditionalCheckFailedException] {
+        Either.catchOnly[ConditionalCheckFailedException] {
           client.updateItem(javaUpdateRequest(req))
         }
     }
@@ -96,9 +96,9 @@ object ScanamoInterpreters {
         futureOf(client.putItemAsync, javaPutRequest(req))
       case ConditionalPut(req) =>
         futureOf(client.putItemAsync, javaPutRequest(req))
-          .map(Xor.right[ConditionalCheckFailedException, PutItemResult])
+          .map(Either.right[ConditionalCheckFailedException, PutItemResult])
           .recover {
-            case e: ConditionalCheckFailedException => Xor.left(e)
+            case e: ConditionalCheckFailedException => Either.left(e)
           }
       case Get(req) =>
         futureOf(client.getItemAsync, req)
@@ -106,8 +106,8 @@ object ScanamoInterpreters {
         futureOf(client.deleteItemAsync, javaDeleteRequest(req))
       case ConditionalDelete(req) =>
         futureOf(client.deleteItemAsync, javaDeleteRequest(req))
-          .map(Xor.right[ConditionalCheckFailedException, DeleteItemResult])
-          .recover { case e: ConditionalCheckFailedException => Xor.left(e) }
+          .map(Either.right[ConditionalCheckFailedException, DeleteItemResult])
+          .recover { case e: ConditionalCheckFailedException => Either.left(e) }
       case Scan(req) =>
         futureOf(client.scanAsync, req)
       case Query(req) =>
@@ -121,9 +121,9 @@ object ScanamoInterpreters {
         futureOf(client.updateItemAsync, javaUpdateRequest(req))
       case ConditionalUpdate(req) =>
         futureOf(client.updateItemAsync, javaUpdateRequest(req))
-          .map(Xor.right[ConditionalCheckFailedException, UpdateItemResult])
+          .map(Either.right[ConditionalCheckFailedException, UpdateItemResult])
           .recover {
-            case e: ConditionalCheckFailedException => Xor.left(e)
+            case e: ConditionalCheckFailedException => Either.left(e)
           }
     }
   }

--- a/src/main/scala/com/gu/scanamo/ops/ScanamoOpsA.scala
+++ b/src/main/scala/com/gu/scanamo/ops/ScanamoOpsA.scala
@@ -1,33 +1,32 @@
 package com.gu.scanamo.ops
 
-import cats.data.Xor
 import com.amazonaws.services.dynamodbv2.model._
 import com.gu.scanamo.request.{ScanamoDeleteRequest, ScanamoPutRequest, ScanamoUpdateRequest}
 
 sealed trait ScanamoOpsA[A] extends Product with Serializable
 final case class Put(req: ScanamoPutRequest) extends ScanamoOpsA[PutItemResult]
-final case class ConditionalPut(req: ScanamoPutRequest) extends ScanamoOpsA[Xor[ConditionalCheckFailedException, PutItemResult]]
+final case class ConditionalPut(req: ScanamoPutRequest) extends ScanamoOpsA[Either[ConditionalCheckFailedException, PutItemResult]]
 final case class Get(req: GetItemRequest) extends ScanamoOpsA[GetItemResult]
 final case class Delete(req: ScanamoDeleteRequest) extends ScanamoOpsA[DeleteItemResult]
-final case class ConditionalDelete(req: ScanamoDeleteRequest) extends ScanamoOpsA[Xor[ConditionalCheckFailedException, DeleteItemResult]]
+final case class ConditionalDelete(req: ScanamoDeleteRequest) extends ScanamoOpsA[Either[ConditionalCheckFailedException, DeleteItemResult]]
 final case class Scan(req: ScanRequest) extends ScanamoOpsA[ScanResult]
 final case class Query(req: QueryRequest) extends ScanamoOpsA[QueryResult]
 final case class BatchWrite(req: BatchWriteItemRequest) extends ScanamoOpsA[BatchWriteItemResult]
 final case class BatchGet(req: BatchGetItemRequest) extends ScanamoOpsA[BatchGetItemResult]
 final case class Update(req: ScanamoUpdateRequest) extends ScanamoOpsA[UpdateItemResult]
-final case class ConditionalUpdate(req: ScanamoUpdateRequest) extends ScanamoOpsA[Xor[ConditionalCheckFailedException, UpdateItemResult]]
+final case class ConditionalUpdate(req: ScanamoUpdateRequest) extends ScanamoOpsA[Either[ConditionalCheckFailedException, UpdateItemResult]]
 
 object ScanamoOps {
 
   import cats.free.Free.liftF
 
   def put(req: ScanamoPutRequest): ScanamoOps[PutItemResult] = liftF[ScanamoOpsA, PutItemResult](Put(req))
-  def conditionalPut(req: ScanamoPutRequest): ScanamoOps[Xor[ConditionalCheckFailedException, PutItemResult]] =
-    liftF[ScanamoOpsA, Xor[ConditionalCheckFailedException, PutItemResult]](ConditionalPut(req))
+  def conditionalPut(req: ScanamoPutRequest): ScanamoOps[Either[ConditionalCheckFailedException, PutItemResult]] =
+    liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, PutItemResult]](ConditionalPut(req))
   def get(req: GetItemRequest): ScanamoOps[GetItemResult] = liftF[ScanamoOpsA, GetItemResult](Get(req))
   def delete(req: ScanamoDeleteRequest): ScanamoOps[DeleteItemResult] = liftF[ScanamoOpsA, DeleteItemResult](Delete(req))
-  def conditionalDelete(req: ScanamoDeleteRequest): ScanamoOps[Xor[ConditionalCheckFailedException, DeleteItemResult]] =
-    liftF[ScanamoOpsA, Xor[ConditionalCheckFailedException, DeleteItemResult]](ConditionalDelete(req))
+  def conditionalDelete(req: ScanamoDeleteRequest): ScanamoOps[Either[ConditionalCheckFailedException, DeleteItemResult]] =
+    liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, DeleteItemResult]](ConditionalDelete(req))
   def scan(req: ScanRequest): ScanamoOps[ScanResult] = liftF[ScanamoOpsA, ScanResult](Scan(req))
   def query(req: QueryRequest): ScanamoOps[QueryResult] = liftF[ScanamoOpsA, QueryResult](Query(req))
   def batchWrite(req: BatchWriteItemRequest): ScanamoOps[BatchWriteItemResult] =
@@ -36,6 +35,6 @@ object ScanamoOps {
     liftF[ScanamoOpsA, BatchGetItemResult](BatchGet(req))
   def update(req: ScanamoUpdateRequest): ScanamoOps[UpdateItemResult] =
     liftF[ScanamoOpsA, UpdateItemResult](Update(req))
-  def conditionalUpdate(req: ScanamoUpdateRequest): ScanamoOps[Xor[ConditionalCheckFailedException, UpdateItemResult]] =
-    liftF[ScanamoOpsA, Xor[ConditionalCheckFailedException, UpdateItemResult]](ConditionalUpdate(req))
+  def conditionalUpdate(req: ScanamoUpdateRequest): ScanamoOps[Either[ConditionalCheckFailedException, UpdateItemResult]] =
+    liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, UpdateItemResult]](ConditionalUpdate(req))
 }

--- a/src/main/scala/com/gu/scanamo/query/ConditionExpression.scala
+++ b/src/main/scala/com/gu/scanamo/query/ConditionExpression.scala
@@ -1,6 +1,5 @@
 package com.gu.scanamo.query
 
-import cats.data.Xor
 import com.amazonaws.services.dynamodbv2.model._
 import com.gu.scanamo.DynamoFormat
 import com.gu.scanamo.error.{ConditionNotMet, ScanamoError}
@@ -8,29 +7,30 @@ import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.request.{RequestCondition, ScanamoDeleteRequest, ScanamoPutRequest, ScanamoUpdateRequest}
 import com.gu.scanamo.update.UpdateExpression
 import simulacrum.typeclass
+import cats.syntax.either._
 
 case class ConditionalOperation[V, T](tableName: String, t: T)(
   implicit state: ConditionExpression[T], format: DynamoFormat[V]) {
-  def put(item: V): ScanamoOps[Xor[ConditionalCheckFailedException, PutItemResult]] = {
+  def put(item: V): ScanamoOps[Either[ConditionalCheckFailedException, PutItemResult]] = {
     val unconditionalRequest = ScanamoPutRequest(tableName, format.write(item), None)
     ScanamoOps.conditionalPut(unconditionalRequest.copy(
       condition = Some(state.apply(t)(unconditionalRequest.condition))))
   }
 
-  def delete(key: UniqueKey[_]): ScanamoOps[Xor[ConditionalCheckFailedException, DeleteItemResult]] = {
+  def delete(key: UniqueKey[_]): ScanamoOps[Either[ConditionalCheckFailedException, DeleteItemResult]] = {
     val unconditionalRequest = ScanamoDeleteRequest(tableName = tableName, key = key.asAVMap, None)
     ScanamoOps.conditionalDelete(unconditionalRequest.copy(
       condition = Some(state.apply(t)(unconditionalRequest.condition))))
   }
 
   def update[U](key: UniqueKey[_], expression: U)(implicit update: UpdateExpression[U]):
-    ScanamoOps[Xor[ScanamoError, V]] = {
+    ScanamoOps[Either[ScanamoError, V]] = {
 
     val unconditionalRequest = ScanamoUpdateRequest(
       tableName, key.asAVMap, update.expression(expression), update.attributeNames(expression), update.attributeValues(expression), None)
     ScanamoOps.conditionalUpdate(unconditionalRequest.copy(
       condition = Some(state.apply(t)(unconditionalRequest.condition)))
-    ).map(xor => xor.leftMap(ConditionNotMet(_)).flatMap(
+    ).map(either => either.leftMap[ScanamoError](ConditionNotMet(_)).flatMap(
       r => format.read(new AttributeValue().withM(r.getAttributes))))
   }
 }

--- a/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -4,7 +4,6 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FunSpec, Matchers}
 import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
-import cats.data.Xor.Right
 import com.gu.scanamo.query.{KeyEquals, KeyList, UniqueKey, UniqueKeys}
 
 class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {


### PR DESCRIPTION
With `Either` becoming left-biased in Scala 2.12, cats is moving away from `Xor`. This is a very literal replacement to try and stay ahead of that change.

As part of a future change, I'd like to represent more errors as values, but this change doesn't address that.