### PR TITLE
Consistent Get/Scan/Query

### DIFF
--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -90,9 +90,27 @@ object Scanamo {
     * Some(Right(Engine(Thomas,1)))
     * }}}
     */
-  def get[T: DynamoFormat](client: AmazonDynamoDB, consistentRead: Boolean = false)(tableName: String)(key: UniqueKey[_])
+  def get[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_])
     : Option[Either[DynamoReadError, T]] =
-    exec(client)(ScanamoFree.get[T](tableName)(key, consistentRead))
+    exec(client)(ScanamoFree.get[T](tableName)(key))
+
+  /**
+    * {{{
+    * >>>  LocalDynamoDB.usingTable(client)("asyncCities")('name -> S) {
+    * ...   case class City(name: String, country: String)
+    * ...   val client = LocalDynamoDB.client()
+    * ...   ScanamoAsync.put(client)("asyncCities")(City("Nashville", "US"))
+    *
+    * ...   import com.gu.scanamo.syntax._
+    * ...   Scanamo.getWithConsistency[City](client)("asyncCities")('name -> "Nashville")
+    * ...  }
+    * Some(Right(City("Nashville", "US")))
+    * }}}
+    */
+
+  def getWithConsistency[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_])
+    : Option[Either[DynamoReadError, T]] =
+    exec(client)(ScanamoFree.getWithConsistency[T](tableName)(key))
 
   /**
     * Returns all the items in the table with matching keys

--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -90,9 +90,9 @@ object Scanamo {
     * Some(Right(Engine(Thomas,1)))
     * }}}
     */
-  def get[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_])
+  def get[T: DynamoFormat](client: AmazonDynamoDB, consistentRead: Boolean = false)(tableName: String)(key: UniqueKey[_])
     : Option[Either[DynamoReadError, T]] =
-    exec(client)(ScanamoFree.get[T](tableName)(key))
+    exec(client)(ScanamoFree.get[T](tableName)(key, consistentRead))
 
   /**
     * Returns all the items in the table with matching keys

--- a/src/main/scala/com/gu/scanamo/Scanamo.scala
+++ b/src/main/scala/com/gu/scanamo/Scanamo.scala
@@ -96,18 +96,19 @@ object Scanamo {
 
   /**
     * {{{
-    * >>>  LocalDynamoDB.usingTable(client)("asyncCities")('name -> S) {
-    * ...   case class City(name: String, country: String)
-    * ...   val client = LocalDynamoDB.client()
-    * ...   ScanamoAsync.put(client)("asyncCities")(City("Nashville", "US"))
+    * >>> case class City(name: String, country: String)
+    * >>> val cityTable = Table[City]("asyncCities")
     *
-    * ...   import com.gu.scanamo.syntax._
-    * ...   Scanamo.getWithConsistency[City](client)("asyncCities")('name -> "Nashville")
-    * ...  }
-    * Some(Right(City("Nashville", "US")))
+    * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+    * >>> val client = LocalDynamoDB.client()
+    * >>> LocalDynamoDB.withTable(client)("asyncCities")('name -> S) {
+    * ...  Scanamo.put(client)("asyncCities")(City("Nashville", "US"))
+    * ...  import com.gu.scanamo.syntax._
+    * ...  Scanamo.getWithConsistency[City](client)("asyncCities")('name -> "Nashville")
+    * ... }
+    * Some(Right(City(Nashville,US)))
     * }}}
     */
-
   def getWithConsistency[T: DynamoFormat](client: AmazonDynamoDB)(tableName: String)(key: UniqueKey[_])
     : Option[Either[DynamoReadError, T]] =
     exec(client)(ScanamoFree.getWithConsistency[T](tableName)(key))

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -29,9 +29,9 @@ object ScanamoAsync {
     (implicit ec: ExecutionContext): Future[List[BatchWriteItemResult]] =
     exec(client)(ScanamoFree.putAll(tableName)(items))
 
-  def get[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
+  def get[T: DynamoFormat](client: AmazonDynamoDBAsync, consistentRead: Boolean = false)(tableName: String)(key: UniqueKey[_])
     (implicit ec: ExecutionContext): Future[Option[Either[DynamoReadError, T]]] =
-    exec(client)(ScanamoFree.get[T](tableName)(key))
+    exec(client)(ScanamoFree.get[T](tableName)(key, consistentRead))
 
   def getAll[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(keys: UniqueKeys[_])
     (implicit ec: ExecutionContext): Future[Set[Either[DynamoReadError, T]]] =

--- a/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoAsync.scala
@@ -29,9 +29,13 @@ object ScanamoAsync {
     (implicit ec: ExecutionContext): Future[List[BatchWriteItemResult]] =
     exec(client)(ScanamoFree.putAll(tableName)(items))
 
-  def get[T: DynamoFormat](client: AmazonDynamoDBAsync, consistentRead: Boolean = false)(tableName: String)(key: UniqueKey[_])
+  def get[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
     (implicit ec: ExecutionContext): Future[Option[Either[DynamoReadError, T]]] =
-    exec(client)(ScanamoFree.get[T](tableName)(key, consistentRead))
+    exec(client)(ScanamoFree.get[T](tableName)(key))
+
+  def getWithConsistency[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(key: UniqueKey[_])
+                          (implicit ec: ExecutionContext): Future[Option[Either[DynamoReadError, T]]] =
+    exec(client)(ScanamoFree.getWithConsistency[T](tableName)(key))
 
   def getAll[T: DynamoFormat](client: AmazonDynamoDBAsync)(tableName: String)(keys: UniqueKeys[_])
     (implicit ec: ExecutionContext): Future[Set[Either[DynamoReadError, T]]] =

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -41,12 +41,20 @@ object ScanamoFree {
     }
   }
 
-  def get[T](tableName: String)(key: UniqueKey[_], consistentRead: Boolean = false)
+  def get[T](tableName: String)(key: UniqueKey[_])
     (implicit ft: DynamoFormat[T]): ScanamoOps[Option[Either[DynamoReadError, T]]] =
     for {
-      res <- ScanamoOps.get(new GetItemRequest().withTableName(tableName).withKey(key.asAVMap.asJava).withConsistentRead(consistentRead))
+      res <- ScanamoOps.get(new GetItemRequest().withTableName(tableName).withKey(key.asAVMap.asJava))
     } yield
       Option(res.getItem).map(read[T])
+
+  def getWithConsistency[T](tableName: String)(key: UniqueKey[_])
+            (implicit ft: DynamoFormat[T]): ScanamoOps[Option[Either[DynamoReadError, T]]] =
+    for {
+      res <- ScanamoOps.get(new GetItemRequest().withTableName(tableName).withKey(key.asAVMap.asJava).withConsistentRead(true))
+    } yield
+      Option(res.getItem).map(read[T])
+
 
   def getAll[T: DynamoFormat](tableName: String)(keys: UniqueKeys[_]): ScanamoOps[Set[Either[DynamoReadError, T]]] = {
     for {

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -41,10 +41,10 @@ object ScanamoFree {
     }
   }
 
-  def get[T](tableName: String)(key: UniqueKey[_])
+  def get[T](tableName: String)(key: UniqueKey[_], consistentRead: Boolean = false)
     (implicit ft: DynamoFormat[T]): ScanamoOps[Option[Either[DynamoReadError, T]]] =
     for {
-      res <- ScanamoOps.get(new GetItemRequest().withTableName(tableName).withKey(key.asAVMap.asJava))
+      res <- ScanamoOps.get(new GetItemRequest().withTableName(tableName).withKey(key.asAVMap.asJava).withConsistentRead(consistentRead))
     } yield
       Option(res.getItem).map(read[T])
 

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -73,6 +73,9 @@ object ScanamoFree {
   def scan[T: DynamoFormat](tableName: String): ScanamoOps[List[Either[DynamoReadError, T]]] =
     ScanResultStream.stream[T](new ScanRequest().withTableName(tableName))
 
+  def scanConsistent[T: DynamoFormat](tableName: String): ScanamoOps[List[Either[DynamoReadError, T]]] =
+    ScanResultStream.stream[T](new ScanRequest().withTableName(tableName).withConsistentRead(true))
+
   def scanWithLimit[T: DynamoFormat](tableName: String, limit: Int): ScanamoOps[List[Either[DynamoReadError, T]]] =
     ScanResultStream.stream[T](new ScanRequest().withTableName(tableName).withLimit(limit))
 
@@ -84,6 +87,9 @@ object ScanamoFree {
 
   def query[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
     QueryResultStream.stream[T](query(new QueryRequest().withTableName(tableName)))
+
+  def queryConsistent[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
+    QueryResultStream.stream[T](query(new QueryRequest().withTableName(tableName).withConsistentRead(true)))
 
   def queryWithLimit[T: DynamoFormat](tableName: String)(query: Query[_], limit: Int): ScanamoOps[List[Either[DynamoReadError, T]]] =
     QueryResultStream.stream[T](query(new QueryRequest().withTableName(tableName)).withLimit(limit))

--- a/src/main/scala/com/gu/scanamo/Table.scala
+++ b/src/main/scala/com/gu/scanamo/Table.scala
@@ -33,7 +33,7 @@ case class Table[V: DynamoFormat](name: String) {
 
   def put(v: V) = ScanamoFree.put(name)(v)
   def putAll(vs: Set[V]) = ScanamoFree.putAll(name)(vs)
-  def get(key: UniqueKey[_]) = ScanamoFree.get[V](name)(key)
+  def get(key: UniqueKey[_], consistentRead: Boolean = false) = ScanamoFree.get[V](name)(key, consistentRead)
   def getAll(keys: UniqueKeys[_]) = ScanamoFree.getAll[V](name)(keys)
   def delete(key: UniqueKey[_]) = ScanamoFree.delete(name)(key)
 

--- a/src/main/scala/com/gu/scanamo/Table.scala
+++ b/src/main/scala/com/gu/scanamo/Table.scala
@@ -198,24 +198,39 @@ case class Table[V: DynamoFormat](name: String) {
   def limit(n: Int) = TableLimit(this, n)
 
   /**
+    * Perform strongly consistent (http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/HowItWorks.ReadConsistency.html)
+    * read operations against this table. Note that there is no equivalent on
+    * table indexes as consistent reads from secondary indexes are not
+    * supported by DynamoDB
+    *
     * {{{
-    * >>> case class City(name: String, country: String)
-    * >>> val cityTable = Table[City]("asyncCities")
+    * >>> case class City(country: String, name: String)
+    * >>> val cityTable = Table[City]("cities")
     *
     * >>> import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
     * >>> val client = LocalDynamoDB.client()
-    * >>> LocalDynamoDB.withTable(client)("asyncCities")('name -> S) {
+    * >>> val (get, scan, query) = LocalDynamoDB.withTable(client)("cities")('country -> S, 'name -> S) {
     * ...   import com.gu.scanamo.syntax._
     * ...   val ops = for {
-    * ...     putRes <- cityTable.put(City("Nashville", "US"))
-    * ...     res <- cityTable.consistent.get('name -> "Nashville")
-    * ...   } yield res
+    * ...     putRes <- cityTable.putAll(Set(
+    * ...       City("US", "Nashville"), City("IT", "Rome"), City("IT", "Siena"), City("TZ", "Dar es Salaam")))
+    * ...     get <- cityTable.consistently.get('country -> "US" and 'name -> "Nashville")
+    * ...     scan <- cityTable.consistently.scan()
+    * ...     query <- cityTable.consistently.query('country -> "IT")
+    * ...   } yield (get, scan, query)
     * ...   Scanamo.exec(client)(ops)
     * ... }
-    * Some(Right(City(Nashville,US)))
+    * >>> get
+    * Some(Right(City(US,Nashville)))
+    *
+    * >>> scan
+    * List(Right(City(US,Nashville)), Right(City(IT,Rome)), Right(City(IT,Siena)), Right(City(TZ,Dar es Salaam)))
+    *
+    * >>> query
+    * List(Right(City(IT,Rome)), Right(City(IT,Siena)))
     * }}}
     */
-  def consistent = TableConsistent(this)
+  def consistently = ConsistentlyReadTable(this)
 
   /**
     * Performs the chained operation, `put` if the condition is met
@@ -454,8 +469,10 @@ private[scanamo] case class IndexLimit[V: DynamoFormat](index: Index[V], limit: 
   def scan() = Scannable.limitedIndexScannable[V].scan(this)
   def query(query: Query[_]) = Queryable.limitedIndexQueryable[V].query(this)(query: Query[_])
 }
-private[scanamo] case class TableConsistent[V: DynamoFormat](table: Table[V]) {
+private[scanamo] case class ConsistentlyReadTable[V: DynamoFormat](table: Table[V]) {
   def get(key: UniqueKey[_]) = Gettable.consistentGettable[V].get(this)(key: UniqueKey[_])
+  def scan() = Scannable.consistentTableScannable[V].scan(this)
+  def query(query: Query[_]) = Queryable.consistentTableQueryable[V].query(this)(query: Query[_])
 }
 
 /* typeclass */trait Scannable[T[_], V] {
@@ -495,6 +512,11 @@ object Scannable {
     override def scan(i: IndexLimit[V])(): ScanamoOps[List[Either[DynamoReadError, V]]] =
       ScanamoFree.scanIndexWithLimit[V](i.index.tableName, i.index.indexName, i.limit)
   }
+
+  implicit def consistentTableScannable[V: DynamoFormat]() = new Scannable[ConsistentlyReadTable, V] {
+    override def scan(t: ConsistentlyReadTable[V])(): ScanamoOps[List[Either[DynamoReadError, V]]] =
+      ScanamoFree.scanConsistent[V](t.table.name)
+  }
 }
 
 /* typeclass */ trait Queryable[T[_], V] {
@@ -533,6 +555,10 @@ object Queryable {
     override def query(i: IndexLimit[V])(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]] =
       ScanamoFree.queryIndexWithLimit[V](i.index.tableName, i.index.indexName)(query, i.limit)
   }
+  implicit def consistentTableQueryable[V: DynamoFormat] = new Queryable[ConsistentlyReadTable, V] {
+    override def query(t: ConsistentlyReadTable[V])(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, V]]] =
+      ScanamoFree.queryConsistent[V](t.table.name)(query)
+  }
 }
 
 /* typeclass */ trait Gettable[T[_], V]{
@@ -542,8 +568,8 @@ object Queryable {
 object Gettable {
   def apply[T[_], V](implicit s: Gettable[T, V]) = s
 
-  implicit def consistentGettable[V: DynamoFormat] = new Gettable[TableConsistent, V] {
-    override def get(t: TableConsistent[V])(key: UniqueKey[_]): ScanamoOps[Option[Either[DynamoReadError, V]]] =
+  implicit def consistentGettable[V: DynamoFormat] = new Gettable[ConsistentlyReadTable, V] {
+    override def get(t: ConsistentlyReadTable[V])(key: UniqueKey[_]): ScanamoOps[Option[Either[DynamoReadError, V]]] =
       ScanamoFree.getWithConsistency[V](t.table.name)(key)
   }
 }

--- a/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -23,6 +23,8 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
       val result = for {
         _ <- ScanamoAsync.put(client)("asyncFarmers")(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield Scanamo.get[Farmer](client)("asyncFarmers")('name -> "McDonald")
+
+      result.futureValue should equal(Some(Right(Farmer("McDonald", 156, Farm(List("sheep", "cow"))))))
     }
   }
 

--- a/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -23,8 +23,6 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
       val result = for {
         _ <- ScanamoAsync.put(client)("asyncFarmers")(Farmer("McDonald", 156L, Farm(List("sheep", "cow"))))
       } yield Scanamo.get[Farmer](client)("asyncFarmers")('name -> "McDonald")
-
-      result.futureValue should equal(Some(Right(Farmer("McDonald", 156, Farm(List("sheep", "cow"))))))
     }
   }
 
@@ -52,6 +50,16 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
       import com.gu.scanamo.syntax._
       ScanamoAsync.get[Engine](client)("asyncEngines")('name -> "Thomas" and 'number -> 1)
         .futureValue should equal(Some(Right(Engine("Thomas", 1))))
+    }
+
+    LocalDynamoDB.usingTable(client)("asyncCities")('name -> S) {
+      case class City(name: String, country: String)
+
+      ScanamoAsync.put(client)("asyncCities")(City("Nashville", "US"))
+
+      import com.gu.scanamo.syntax._
+      ScanamoAsync.get[City](client, true)("asyncCities")('name -> "Nashville")
+        .futureValue should equal(Some(Right(City("Nashville", "US"))))
     }
   }
 

--- a/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoAsyncTest.scala
@@ -53,14 +53,16 @@ class ScanamoAsyncTest extends FunSpec with Matchers with ScalaFutures {
       ScanamoAsync.get[Engine](client)("asyncEngines")('name -> "Thomas" and 'number -> 1)
         .futureValue should equal(Some(Right(Engine("Thomas", 1))))
     }
+  }
 
+  it("should get consistently asynchronously") {
+    case class City(name: String, country: String)
     LocalDynamoDB.usingTable(client)("asyncCities")('name -> S) {
-      case class City(name: String, country: String)
 
       ScanamoAsync.put(client)("asyncCities")(City("Nashville", "US"))
 
       import com.gu.scanamo.syntax._
-      ScanamoAsync.get[City](client, true)("asyncCities")('name -> "Nashville")
+      ScanamoAsync.getWithConsistency[City](client)("asyncCities")('name -> "Nashville")
         .futureValue should equal(Some(Right(City("Nashville", "US"))))
     }
   }

--- a/src/test/scala/com/gu/scanamo/ScanamoTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoTest.scala
@@ -17,4 +17,16 @@ class ScanamoTest extends org.scalatest.FunSpec with org.scalatest.Matchers {
 
     val deleteResult = client.deleteTable("large-query")
   }
+
+  it("should get consistently") {
+    val client = LocalDynamoDB.client()
+    case class City(name: String, country: String)
+    LocalDynamoDB.usingTable(client)("asyncCities")('name -> S) {
+
+      Scanamo.put(client)("asyncCities")(City("Nashville", "US"))
+
+      import com.gu.scanamo.syntax._
+      Scanamo.getWithConsistency[City](client)("asyncCities")('name -> "Nashville") should equal(Some(Right(City("Nashville", "US"))))
+    }
+  }
 }

--- a/src/test/scala/com/gu/scanamo/ScanamoTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoTest.scala
@@ -42,7 +42,7 @@ class ScanamoTest extends org.scalatest.FunSpec with org.scalatest.Matchers {
       import com.gu.scanamo.syntax._
       val ops = for {
         _ <- cityTable.put(City("Nashville", "US"))
-        res <- cityTable.consistent.get('name -> "Nashville")
+        res <- cityTable.consistently.get('name -> "Nashville")
       } yield res
       Scanamo.exec(client)(ops) should equal(Some(Right(City("Nashville", "US"))))
     }


### PR DESCRIPTION
This builds on #71 to add support consistent Scan/Query, as  I wanted to see what that looked like.

It would be good to add some tests which actually require consistency to verify that works as desired.