### PR TITLE
Fix documentation example for 2.11

### DIFF
--- a/src/main/tut/batch-operations.md
+++ b/src/main/tut/batch-operations.md
@@ -34,6 +34,7 @@ val ops = for {
   survivors <- lemmingsTable.scan()
 } yield (bLemmings, survivors)
 val (bLemmings, survivors) = Scanamo.exec(client)(ops)
+import cats.syntax.either._
 bLemmings.flatMap(_.toOption)
 survivors.flatMap(_.toOption)
 ```


### PR DESCRIPTION
`toOption` is only in stdlib in 2.12, need cats syntax for example to compile on 2.11