### PR TITLE
Support derivation of coproducts

### DIFF
--- a/src/main/scala/com/gu/scanamo/DynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/DynamoFormat.scala
@@ -35,6 +35,35 @@ import java.nio.ByteBuffer
   * Right(Farmer(McDonald,156,Farm(List(sheep, cow))))
   * }}}
   *
+  * and for sealed trait + case object hierarchies
+  *
+  * {{{
+  * >>> sealed trait Animal
+  * >>> case object Aardvark extends Animal
+  * >>> case object Zebra extends Animal
+  * >>> case class Pet(name: String, animal: Animal)
+  * >>> val petF = DynamoFormat[Pet]
+  * >>> petF.read(petF.write(Pet("Amy", Aardvark)))
+  * Right(Pet(Amy,Aardvark))
+  *
+  * >>> petF.read(petF.write(Pet("Zebediah", Zebra)))
+  * Right(Pet(Zebediah,Zebra))
+  * }}}
+  *
+  * as well as more complex sealed trait + case class hierarchies
+  *
+  * {{{
+  * >>> sealed trait Monster
+  * >>> case object Godzilla extends Monster
+  * >>> case class GiantSquid(tentacles: Int) extends Monster
+  * >>> val monsterF = DynamoFormat[Monster]
+  * >>> monsterF.read(monsterF.write(Godzilla))
+  * Right(Godzilla)
+  *
+  * >>> monsterF.read(monsterF.write(GiantSquid(12)))
+  * Right(GiantSquid(12))
+  * }}}
+  *
   * Problems reading a value are detailed
   * {{{
   * >>> import cats.syntax.either._


### PR DESCRIPTION
Coproducts are encoded as a map with one field, whose key is the type hint.

e.g. given

```scala
sealed trait Animal
case class Cat(name: String, legs: Int) extends Animal

val cat = Cat("Eric", 4)
```

`cat` would be encoded in Dynamo as (using jsony syntax) `{ "Cat": { "name": "Eric", "legs": 4 } }`

I feel like there must be a good reason why @philwills decided not to implement this until now, but I think it is pretty useful. For example it means you can encode enumerations using a sealed trait + case objects, which is a very common thing to do, without having to write a boilerplate-y custom `DynamoFormat`.