### PR TITLE
Create list if it does not exist when appending/prepending

### DIFF
--- a/src/main/scala/com/gu/scanamo/Table.scala
+++ b/src/main/scala/com/gu/scanamo/Table.scala
@@ -134,6 +134,20 @@ case class Table[V: DynamoFormat](name: String) {
     * List(Right(Character(The Doctor,List(McCoy, Ecclestone, Tennant, Smith, Capaldi))))
     * }}}
     *
+    * Appending or prepending creates the list if it does not yet exist:
+    *
+    * {{{
+    * >>> LocalDynamoDB.withTable(client)("characters")('name -> S) {
+    * ...   import com.gu.scanamo.syntax._
+    * ...   val operations = for {
+    * ...     _ <- characters.update('name -> "James Bond", append('actors -> "Craig"))
+    * ...     results <- characters.query('name -> "James Bond")
+    * ...   } yield results.toList
+    * ...   Scanamo.exec(client)(operations)
+    * ... }
+    * List(Right(Character(James Bond,List(Craig))))
+    * }}}
+    *
     * Multiple operations can also be performed in one call:
     * {{{
     * >>> case class Foo(name: String, bar: Int, l: List[String])

--- a/src/main/scala/com/gu/scanamo/update/UpdateExpression.scala
+++ b/src/main/scala/com/gu/scanamo/update/UpdateExpression.scala
@@ -39,11 +39,14 @@ object AppendExpression {
   implicit def appendUpdateExpression[V](implicit format: DynamoFormat[V]) =
     new UpdateExpression[AppendExpression[V]] {
       override def typeExpressions(t: AppendExpression[V]): Map[UpdateType, String] =
-        Map(SET -> "#update = list_append(#update, :update)")
+        Map(SET -> "#update = list_append(if_not_exists(#update, :emptyList), :update)")
       override def attributeNames(t: AppendExpression[V]): Map[String, String] =
         Map("#update" -> t.field.name)
       override def attributeValues(t: AppendExpression[V]): Map[String, AttributeValue] =
-        Map(":update" -> DynamoFormat.listFormat[V].write(List(t.value)))
+        Map(
+          ":update" -> DynamoFormat.listFormat[V].write(List(t.value)),
+          ":emptyList" -> new AttributeValue().withL()
+        )
     }
 }
 
@@ -53,11 +56,14 @@ object PrependExpression {
   implicit def appendUpdateExpression[V](implicit format: DynamoFormat[V]) =
     new UpdateExpression[PrependExpression[V]] {
       override def typeExpressions(t: PrependExpression[V]): Map[UpdateType, String] =
-        Map(SET -> "#update = list_append(:update, #update)")
+        Map(SET -> "#update = list_append(:update, if_not_exists(#update, :emptyList))")
       override def attributeNames(t: PrependExpression[V]): Map[String, String] =
         Map("#update" -> t.field.name)
       override def attributeValues(t: PrependExpression[V]): Map[String, AttributeValue] =
-        Map(":update" -> DynamoFormat.listFormat[V].write(List(t.value)))
+        Map(
+          ":update" -> DynamoFormat.listFormat[V].write(List(t.value)),
+          ":emptyList" -> new AttributeValue().withL()
+        )
     }
 }
 


### PR DESCRIPTION
This avoids the following error: `The provided expression refers to an attribute that does not exist in the item`