### PR TITLE
Filtering of Scan and Query

### DIFF
--- a/src/main/scala/com/gu/scanamo/DynamoResultStream.scala
+++ b/src/main/scala/com/gu/scanamo/DynamoResultStream.scala
@@ -6,7 +6,7 @@ import cats.free.Free
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, QueryRequest, QueryResult, ScanRequest, ScanResult}
 import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.ops.{ScanamoOps, ScanamoOpsA}
-import com.gu.scanamo.request.ScanamoScanRequest
+import com.gu.scanamo.request.{ScanamoQueryRequest, ScanamoScanRequest}
 
 import collection.JavaConverters._
 
@@ -51,14 +51,14 @@ private[scanamo] object DynamoResultStream {
     override def limit(req: ScanamoScanRequest): Option[Int] = req.options.limit
   }
 
-  object QueryResultStream extends DynamoResultStream[QueryRequest, QueryResult] {
+  object QueryResultStream extends DynamoResultStream[ScanamoQueryRequest, QueryResult] {
     override def items(res: QueryResult): util.List[util.Map[String, AttributeValue]] = res.getItems
     override def lastEvaluatedKey(res: QueryResult): util.Map[String, AttributeValue] = res.getLastEvaluatedKey
-    override def withExclusiveStartKey(req: QueryRequest, key: util.Map[String, AttributeValue]): QueryRequest =
-      req.withExclusiveStartKey(key)
+    override def withExclusiveStartKey(req: ScanamoQueryRequest, key: util.Map[String, AttributeValue]): ScanamoQueryRequest =
+      req.copy(options = req.options.copy(exclusiveStartKey = Some(key.asScala.toMap)))
 
-    override def exec(req: QueryRequest): ScanamoOps[QueryResult] = ScanamoOps.query(req)
+    override def exec(req: ScanamoQueryRequest): ScanamoOps[QueryResult] = ScanamoOps.query(req)
 
-    override def limit(req: QueryRequest): Option[Int] = Option(req.getLimit).map(_.intValue)
+    override def limit(req: ScanamoQueryRequest): Option[Int] = req.options.limit
   }
 }

--- a/src/main/scala/com/gu/scanamo/DynamoResultStream.scala
+++ b/src/main/scala/com/gu/scanamo/DynamoResultStream.scala
@@ -6,6 +6,7 @@ import cats.free.Free
 import com.amazonaws.services.dynamodbv2.model.{AttributeValue, QueryRequest, QueryResult, ScanRequest, ScanResult}
 import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.ops.{ScanamoOps, ScanamoOpsA}
+import com.gu.scanamo.request.ScanamoScanRequest
 
 import collection.JavaConverters._
 
@@ -39,15 +40,15 @@ private[scanamo] trait DynamoResultStream[Req, Res] {
 }
 
 private[scanamo] object DynamoResultStream {
-  object ScanResultStream extends DynamoResultStream[ScanRequest, ScanResult] {
+  object ScanResultStream extends DynamoResultStream[ScanamoScanRequest, ScanResult] {
     override def items(res: ScanResult): util.List[util.Map[String, AttributeValue]] = res.getItems
     override def lastEvaluatedKey(res: ScanResult): util.Map[String, AttributeValue] = res.getLastEvaluatedKey
-    override def withExclusiveStartKey(req: ScanRequest, key: util.Map[String, AttributeValue]): ScanRequest =
-      req.withExclusiveStartKey(key)
+    override def withExclusiveStartKey(req: ScanamoScanRequest, key: util.Map[String, AttributeValue]): ScanamoScanRequest =
+      req.copy(options = req.options.copy(exclusiveStartKey = Some(key.asScala.toMap)))
 
-    override def exec(req: ScanRequest): ScanamoOps[ScanResult] = ScanamoOps.scan(req)
+    override def exec(req: ScanamoScanRequest): ScanamoOps[ScanResult] = ScanamoOps.scan(req)
 
-    override def limit(req: ScanRequest): Option[Int] = Option(req.getLimit).map(_.intValue)
+    override def limit(req: ScanamoScanRequest): Option[Int] = req.options.limit
   }
 
   object QueryResultStream extends DynamoResultStream[QueryRequest, QueryResult] {

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -5,7 +5,7 @@ import com.gu.scanamo.DynamoResultStream.{QueryResultStream, ScanResultStream}
 import com.gu.scanamo.error.DynamoReadError
 import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.query._
-import com.gu.scanamo.request.{ScanamoDeleteRequest, ScanamoPutRequest, ScanamoUpdateRequest}
+import com.gu.scanamo.request._
 import com.gu.scanamo.update.UpdateExpression
 
 object ScanamoFree {
@@ -71,19 +71,19 @@ object ScanamoFree {
     ScanamoOps.delete(ScanamoDeleteRequest(tableName, key.asAVMap, None))
 
   def scan[T: DynamoFormat](tableName: String): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    ScanResultStream.stream[T](new ScanRequest().withTableName(tableName))
+    ScanResultStream.stream[T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default))
 
   def scanConsistent[T: DynamoFormat](tableName: String): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    ScanResultStream.stream[T](new ScanRequest().withTableName(tableName).withConsistentRead(true))
+    ScanResultStream.stream[T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default.copy(consistent = true)))
 
   def scanWithLimit[T: DynamoFormat](tableName: String, limit: Int): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    ScanResultStream.stream[T](new ScanRequest().withTableName(tableName).withLimit(limit))
+    ScanResultStream.stream[T](ScanamoScanRequest(tableName, None, ScanamoQueryOptions.default.copy(limit = Some(limit))))
 
   def scanIndex[T: DynamoFormat](tableName: String, indexName: String): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    ScanResultStream.stream[T](new ScanRequest().withTableName(tableName).withIndexName(indexName))
+    ScanResultStream.stream[T](ScanamoScanRequest(tableName, Some(indexName), ScanamoQueryOptions.default))
 
   def scanIndexWithLimit[T: DynamoFormat](tableName: String, indexName: String, limit: Int): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    ScanResultStream.stream[T](new ScanRequest().withTableName(tableName).withIndexName(indexName).withLimit(limit))
+    ScanResultStream.stream[T](ScanamoScanRequest(tableName, Some(indexName), ScanamoQueryOptions.default.copy(limit = Some(limit))))
 
   def query[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
     QueryResultStream.stream[T](query(new QueryRequest().withTableName(tableName)))

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -86,19 +86,19 @@ object ScanamoFree {
     ScanResultStream.stream[T](ScanamoScanRequest(tableName, Some(indexName), ScanamoQueryOptions.default.copy(limit = Some(limit))))
 
   def query[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    QueryResultStream.stream[T](query(new QueryRequest().withTableName(tableName)))
+    QueryResultStream.stream[T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default))
 
   def queryConsistent[T: DynamoFormat](tableName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    QueryResultStream.stream[T](query(new QueryRequest().withTableName(tableName).withConsistentRead(true)))
+    QueryResultStream.stream[T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default.copy(consistent = true)))
 
   def queryWithLimit[T: DynamoFormat](tableName: String)(query: Query[_], limit: Int): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    QueryResultStream.stream[T](query(new QueryRequest().withTableName(tableName)).withLimit(limit))
+    QueryResultStream.stream[T](ScanamoQueryRequest(tableName, None, query, ScanamoQueryOptions.default.copy(limit = Some(limit))))
 
   def queryIndex[T: DynamoFormat](tableName: String, indexName: String)(query: Query[_]): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    QueryResultStream.stream[T](query(new QueryRequest().withTableName(tableName)).withIndexName(indexName))
+    QueryResultStream.stream[T](ScanamoQueryRequest(tableName, Some(indexName), query, ScanamoQueryOptions.default))
 
   def queryIndexWithLimit[T: DynamoFormat](tableName: String, indexName: String)(query: Query[_], limit: Int): ScanamoOps[List[Either[DynamoReadError, T]]] =
-    QueryResultStream.stream[T](query(new QueryRequest().withTableName(tableName)).withIndexName(indexName).withLimit(limit))
+    QueryResultStream.stream[T](ScanamoQueryRequest(tableName, Some(indexName), query, ScanamoQueryOptions.default.copy(limit = Some(limit))))
 
   def update[T](tableName: String)(key: UniqueKey[_])(update: UpdateExpression)(
     implicit format: DynamoFormat[T]

--- a/src/main/scala/com/gu/scanamo/ops/ScanamoOpsA.scala
+++ b/src/main/scala/com/gu/scanamo/ops/ScanamoOpsA.scala
@@ -1,7 +1,7 @@
 package com.gu.scanamo.ops
 
 import com.amazonaws.services.dynamodbv2.model._
-import com.gu.scanamo.request.{ScanamoDeleteRequest, ScanamoPutRequest, ScanamoScanRequest, ScanamoUpdateRequest}
+import com.gu.scanamo.request._
 
 sealed trait ScanamoOpsA[A] extends Product with Serializable
 final case class Put(req: ScanamoPutRequest) extends ScanamoOpsA[PutItemResult]
@@ -10,7 +10,7 @@ final case class Get(req: GetItemRequest) extends ScanamoOpsA[GetItemResult]
 final case class Delete(req: ScanamoDeleteRequest) extends ScanamoOpsA[DeleteItemResult]
 final case class ConditionalDelete(req: ScanamoDeleteRequest) extends ScanamoOpsA[Either[ConditionalCheckFailedException, DeleteItemResult]]
 final case class Scan(req: ScanamoScanRequest) extends ScanamoOpsA[ScanResult]
-final case class Query(req: QueryRequest) extends ScanamoOpsA[QueryResult]
+final case class Query(req: ScanamoQueryRequest) extends ScanamoOpsA[QueryResult]
 final case class BatchWrite(req: BatchWriteItemRequest) extends ScanamoOpsA[BatchWriteItemResult]
 final case class BatchGet(req: BatchGetItemRequest) extends ScanamoOpsA[BatchGetItemResult]
 final case class Update(req: ScanamoUpdateRequest) extends ScanamoOpsA[UpdateItemResult]
@@ -28,7 +28,7 @@ object ScanamoOps {
   def conditionalDelete(req: ScanamoDeleteRequest): ScanamoOps[Either[ConditionalCheckFailedException, DeleteItemResult]] =
     liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, DeleteItemResult]](ConditionalDelete(req))
   def scan(req: ScanamoScanRequest): ScanamoOps[ScanResult] = liftF[ScanamoOpsA, ScanResult](Scan(req))
-  def query(req: QueryRequest): ScanamoOps[QueryResult] = liftF[ScanamoOpsA, QueryResult](Query(req))
+  def query(req: ScanamoQueryRequest): ScanamoOps[QueryResult] = liftF[ScanamoOpsA, QueryResult](Query(req))
   def batchWrite(req: BatchWriteItemRequest): ScanamoOps[BatchWriteItemResult] =
     liftF[ScanamoOpsA, BatchWriteItemResult](BatchWrite(req))
   def batchGet(req: BatchGetItemRequest): ScanamoOps[BatchGetItemResult] =

--- a/src/main/scala/com/gu/scanamo/ops/ScanamoOpsA.scala
+++ b/src/main/scala/com/gu/scanamo/ops/ScanamoOpsA.scala
@@ -1,7 +1,7 @@
 package com.gu.scanamo.ops
 
 import com.amazonaws.services.dynamodbv2.model._
-import com.gu.scanamo.request.{ScanamoDeleteRequest, ScanamoPutRequest, ScanamoUpdateRequest}
+import com.gu.scanamo.request.{ScanamoDeleteRequest, ScanamoPutRequest, ScanamoScanRequest, ScanamoUpdateRequest}
 
 sealed trait ScanamoOpsA[A] extends Product with Serializable
 final case class Put(req: ScanamoPutRequest) extends ScanamoOpsA[PutItemResult]
@@ -9,7 +9,7 @@ final case class ConditionalPut(req: ScanamoPutRequest) extends ScanamoOpsA[Eith
 final case class Get(req: GetItemRequest) extends ScanamoOpsA[GetItemResult]
 final case class Delete(req: ScanamoDeleteRequest) extends ScanamoOpsA[DeleteItemResult]
 final case class ConditionalDelete(req: ScanamoDeleteRequest) extends ScanamoOpsA[Either[ConditionalCheckFailedException, DeleteItemResult]]
-final case class Scan(req: ScanRequest) extends ScanamoOpsA[ScanResult]
+final case class Scan(req: ScanamoScanRequest) extends ScanamoOpsA[ScanResult]
 final case class Query(req: QueryRequest) extends ScanamoOpsA[QueryResult]
 final case class BatchWrite(req: BatchWriteItemRequest) extends ScanamoOpsA[BatchWriteItemResult]
 final case class BatchGet(req: BatchGetItemRequest) extends ScanamoOpsA[BatchGetItemResult]
@@ -27,7 +27,7 @@ object ScanamoOps {
   def delete(req: ScanamoDeleteRequest): ScanamoOps[DeleteItemResult] = liftF[ScanamoOpsA, DeleteItemResult](Delete(req))
   def conditionalDelete(req: ScanamoDeleteRequest): ScanamoOps[Either[ConditionalCheckFailedException, DeleteItemResult]] =
     liftF[ScanamoOpsA, Either[ConditionalCheckFailedException, DeleteItemResult]](ConditionalDelete(req))
-  def scan(req: ScanRequest): ScanamoOps[ScanResult] = liftF[ScanamoOpsA, ScanResult](Scan(req))
+  def scan(req: ScanamoScanRequest): ScanamoOps[ScanResult] = liftF[ScanamoOpsA, ScanResult](Scan(req))
   def query(req: QueryRequest): ScanamoOps[QueryResult] = liftF[ScanamoOpsA, QueryResult](Query(req))
   def batchWrite(req: BatchWriteItemRequest): ScanamoOps[BatchWriteItemResult] =
     liftF[ScanamoOpsA, BatchWriteItemResult](BatchWrite(req))

--- a/src/main/scala/com/gu/scanamo/package.scala
+++ b/src/main/scala/com/gu/scanamo/package.scala
@@ -5,7 +5,7 @@ import com.gu.scanamo.update._
 
 package object scanamo {
 
-  object syntax extends Scannable.ToScannableOps with Queryable.ToQueryableOps {
+  object syntax {
     implicit class SymbolKeyCondition(s: Symbol) {
       def <[V: DynamoFormat](v: V) = KeyIs(s, LT, v)
       def >[V: DynamoFormat](v: V) = KeyIs(s, GT, v)

--- a/src/main/scala/com/gu/scanamo/query/ConditionExpression.scala
+++ b/src/main/scala/com/gu/scanamo/query/ConditionExpression.scala
@@ -142,6 +142,7 @@ case class AndCondition[L: ConditionExpression, R: ConditionExpression](l: L, r:
 case class OrCondition[L: ConditionExpression, R: ConditionExpression](l: L, r: R)
 
 case class Condition[T: ConditionExpression](t: T) {
+  def apply(condition: Option[RequestCondition]) = implicitly[ConditionExpression[T]].apply(t)(condition)
   def and[Y: ConditionExpression](other: Y) = AndCondition(t, other)
   def or[Y: ConditionExpression](other: Y) = OrCondition(t, other)
 }

--- a/src/main/scala/com/gu/scanamo/request/ScanamoRequest.scala
+++ b/src/main/scala/com/gu/scanamo/request/ScanamoRequest.scala
@@ -23,6 +23,21 @@ case class ScanamoUpdateRequest(
   condition: Option[RequestCondition]
 )
 
+case class ScanamoScanRequest(
+  tableName: String,
+  index: Option[String],
+  options: ScanamoQueryOptions
+)
+
+case class ScanamoQueryOptions(
+  consistent: Boolean,
+  limit: Option[Int],
+  exclusiveStartKey: Option[Map[String, AttributeValue]]
+)
+object ScanamoQueryOptions {
+  val default = ScanamoQueryOptions(false, None, None)
+}
+
 case class RequestCondition(
   expression: String,
   attributeNames: Map[String, String],

--- a/src/main/scala/com/gu/scanamo/request/ScanamoRequest.scala
+++ b/src/main/scala/com/gu/scanamo/request/ScanamoRequest.scala
@@ -1,6 +1,7 @@
 package com.gu.scanamo.request
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import com.gu.scanamo.query.{Condition, ConditionExpression, Query}
 
 case class ScanamoPutRequest(
   tableName: String,
@@ -29,13 +30,21 @@ case class ScanamoScanRequest(
   options: ScanamoQueryOptions
 )
 
+case class ScanamoQueryRequest(
+  tableName: String,
+  index: Option[String],
+  query: Query[_],
+  options: ScanamoQueryOptions
+)
+
 case class ScanamoQueryOptions(
   consistent: Boolean,
   limit: Option[Int],
-  exclusiveStartKey: Option[Map[String, AttributeValue]]
+  exclusiveStartKey: Option[Map[String, AttributeValue]],
+  filter: Option[Condition[_]]
 )
 object ScanamoQueryOptions {
-  val default = ScanamoQueryOptions(false, None, None)
+  val default = ScanamoQueryOptions(false, None, None, None)
 }
 
 case class RequestCondition(

--- a/src/test/scala/com/gu/scanamo/ScanamoFreeTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoFreeTest.scala
@@ -51,7 +51,7 @@ class RequestCountingInterpreter extends (ScanamoOpsA ~> RequestCountingInterpre
     case Query(req) => State(counter =>
       if (counter < 42)
         counter + 1 -> new QueryResult().withLastEvaluatedKey(Map("x" -> DynamoFormat[Int].write(1)).asJava)
-            .withItems(List.fill(req.getLimit)(new util.HashMap[String, AttributeValue]()): _*)
+            .withItems(List.fill(req.options.limit.getOrElse(0))(new util.HashMap[String, AttributeValue]()): _*)
       else
         counter -> new QueryResult().withItems(List.empty[java.util.Map[String, AttributeValue]].asJava)
     )

--- a/src/test/scala/com/gu/scanamo/ScanamoFreeTest.scala
+++ b/src/test/scala/com/gu/scanamo/ScanamoFreeTest.scala
@@ -43,7 +43,7 @@ class RequestCountingInterpreter extends (ScanamoOpsA ~> RequestCountingInterpre
     case Scan(req) => State(counter =>
       if (counter < 42)
         counter + 1 -> new ScanResult().withLastEvaluatedKey(Map("x" -> DynamoFormat[Int].write(1)).asJava)
-          .withItems(List.fill(Option(req.getLimit).map(_.toInt).getOrElse(50))(
+          .withItems(List.fill(req.options.limit.getOrElse(50))(
             new util.HashMap[String, AttributeValue]()): _*)
       else
         counter -> new ScanResult().withItems(List.empty[java.util.Map[String, AttributeValue]].asJava)


### PR DESCRIPTION
Support filtering of `Scan` and `Query` results in DynamoDB before they are returned to the client.

Addresses #42 