### PR TITLE
Cats 1.0.0-MF changes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ organization := "com.gu"
 
 scalaVersion := "2.12.1"
 
-crossScalaVersions := Seq("2.11.8", scalaVersion.value)
+crossScalaVersions := Seq("2.11.11", scalaVersion.value)
 
 resolvers += Resolver.sonatypeRepo("snapshots")
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ resolvers += Resolver.sonatypeRepo("snapshots")
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.11.154",
   "com.chuusai" %% "shapeless" % "2.3.2",
-  "org.typelevel" %% "cats-free" % "0.9.0",
+  "org.typelevel" %% "cats-free" % "1.0.0-MF",
   "com.github.mpilquist" %% "simulacrum" % "0.10.0",
 
   // Use Joda for custom conversion example
@@ -36,7 +36,8 @@ scalacOptions := Seq(
   "-Yno-adapted-args",
   "-Ywarn-dead-code",
   "-Ywarn-numeric-widen",
-  "-Ywarn-value-discard"
+  "-Ywarn-value-discard",
+  "-Ypartial-unification"
 )
 
 dynamoDBLocalDownloadDir := file(".dynamodb-local")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,3 +13,5 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+
+addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -13,5 +13,3 @@ addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.1")
 
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
 addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
-
-addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.0")

--- a/src/main/scala/com/gu/scanamo/DynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/DynamoFormat.scala
@@ -276,7 +276,7 @@ object DynamoFormat extends EnumDynamoFormat {
     */
   implicit def listFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[List[T]] =
     xmap[List[T], java.util.List[AttributeValue]](
-      _.asScala.toList.traverseU(f.read))(
+      _.asScala.toList.traverse(f.read))(
       _.map(f.write).asJava
     )(javaListFormat)
 
@@ -299,7 +299,7 @@ object DynamoFormat extends EnumDynamoFormat {
     */
   implicit def vectorFormat[T](implicit f: DynamoFormat[T]): DynamoFormat[Vector[T]] =
     xmap[Vector[T], java.util.List[AttributeValue]](
-      _.asScala.toVector.traverseU(f.read))(
+      _.asScala.toVector.traverse(f.read))(
       _.map(f.write).asJava
     )(javaListFormat)
 
@@ -312,7 +312,7 @@ object DynamoFormat extends EnumDynamoFormat {
     */
   implicit def arrayFormat[T:ClassTag](implicit f: DynamoFormat[T]): DynamoFormat[Array[T]] =
     xmap[Array[T], java.util.List[AttributeValue]](
-      _.asScala.toList.traverseU(f.read).map(_.toArray))(
+      _.asScala.toList.traverse(f.read).map(_.toArray))(
       _.map(f.write).toList.asJava
     )(javaListFormat)
 
@@ -320,7 +320,7 @@ object DynamoFormat extends EnumDynamoFormat {
   private val javaStringSetFormat = attribute(_.getSS, "SS")(_.withSS)
   private def setFormat[T](r: String => Either[DynamoReadError, T])(w: T => String)(df: DynamoFormat[java.util.List[String]]): DynamoFormat[Set[T]] =
     xmap[Set[T], java.util.List[String]](
-      _.asScala.toList.traverseU(r).map(_.toSet))(
+      _.asScala.toList.traverse(r).map(_.toSet))(
       _.map(w).toList.asJava
     )(df)
 
@@ -383,7 +383,7 @@ object DynamoFormat extends EnumDynamoFormat {
     */
   implicit def mapFormat[V](implicit f: DynamoFormat[V]): DynamoFormat[Map[String, V]] =
     xmap[Map[String, V], java.util.Map[String, AttributeValue]](
-      _.asScala.toMap.traverseU(f.read))(
+      _.asScala.toMap.traverse(f.read))(
       _.mapValues(f.write).asJava
     )(javaMapFormat)
 

--- a/src/main/scala/com/gu/scanamo/ScanamoFree.scala
+++ b/src/main/scala/com/gu/scanamo/ScanamoFree.scala
@@ -20,7 +20,7 @@ object ScanamoFree {
     ScanamoOps.put(ScanamoPutRequest(tableName, f.write(item), None))
 
   def putAll[T](tableName: String)(items: Set[T])(implicit f: DynamoFormat[T]): ScanamoOps[List[BatchWriteItemResult]] =
-    items.grouped(batchSize).toList.traverseU(batch =>
+    items.grouped(batchSize).toList.traverse(batch =>
       ScanamoOps.batchWrite(
         new BatchWriteItemRequest().withRequestItems(Map(tableName -> batch.toList.map(i =>
           new WriteRequest().withPutRequest(new PutRequest().withItem(f.write(i).getM))
@@ -29,7 +29,7 @@ object ScanamoFree {
     )
 
   def deleteAll(tableName: String)(items: UniqueKeys[_]): ScanamoOps[List[BatchWriteItemResult]] = {
-    items.asAVMap.grouped(batchSize).toList.traverseU { batch =>
+    items.asAVMap.grouped(batchSize).toList.traverse { batch =>
       ScanamoOps.batchWrite(
         new BatchWriteItemRequest().withRequestItems(
           Map(tableName -> batch.toList
@@ -56,7 +56,7 @@ object ScanamoFree {
       Option(res.getItem).map(read[T])
 
   def getAll[T: DynamoFormat](tableName: String)(keys: UniqueKeys[_]): ScanamoOps[Set[Either[DynamoReadError, T]]] = {
-    keys.asAVMap.grouped(batchSize).toList.traverseU { batch =>
+    keys.asAVMap.grouped(batchSize).toList.traverse { batch =>
       ScanamoOps.batchGet(
         new BatchGetItemRequest().withRequestItems(Map(tableName ->
           new KeysAndAttributes().withKeys(batch.map(_.asJava).asJava)


### PR DESCRIPTION
To achieve this change `traverseU` was changed to `traverse`. 

Updated to scala 2.11.11 so partial unification was available.