### PR TITLE
Don't allow an empty map to be derived as a DynamoFormat

### DIFF
--- a/src/main/scala/com/gu/scanamo/DynamoFormat.scala
+++ b/src/main/scala/com/gu/scanamo/DynamoFormat.scala
@@ -52,20 +52,6 @@ import scala.reflect.ClassTag
   * Right(Pet(Zebediah,Zebra))
   * }}}
   *
-  * as well as more complex sealed trait + case class hierarchies
-  *
-  * {{{
-  * >>> sealed trait Monster
-  * >>> case object Godzilla extends Monster
-  * >>> case class GiantSquid(tentacles: Int) extends Monster
-  * >>> val monsterF = DynamoFormat[Monster]
-  * >>> monsterF.read(monsterF.write(Godzilla))
-  * Right(Godzilla)
-  *
-  * >>> monsterF.read(monsterF.write(GiantSquid(12)))
-  * Right(GiantSquid(12))
-  * }}}
-  *
   * Problems reading a value are detailed
   * {{{
   * >>> import cats.syntax.either._

--- a/src/test/scala/com/gu/scanamo/EnumDynamoFormatTest.scala
+++ b/src/test/scala/com/gu/scanamo/EnumDynamoFormatTest.scala
@@ -1,0 +1,19 @@
+package com.gu.scanamo
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import org.scalatest.{FunSuite, Matchers}
+
+class EnumDynamoFormatTest extends FunSuite with Matchers {
+
+  test("automatic derivation for case object should only work if treating it as an enum") {
+    write[ExampleEnum](First) shouldBe (new AttributeValue().withS("First"))
+    "write(First)" shouldNot typeCheck
+  }
+
+  def write[T](t: T)(implicit f: DynamoFormat[T]) = f.write(t)
+}
+
+
+sealed trait ExampleEnum
+case object First extends ExampleEnum
+


### PR DESCRIPTION
`new AttributeValue().withM(Map.empty[String, AttributeValue].asJava)`

is a base to build from, but cannot be written to Dynamo, so should
never be derived as the serialisation form for a type.

This moves the problems with #138 to compile time, rather than run time.