### PR TITLE
Disable unused warnings for the console

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -48,6 +48,7 @@ scalacOptions in Test := {
   else
     scalacOptions.value
 }
+scalacOptions in (Compile, console) := (scalacOptions in Test).value
 
 dynamoDBLocalDownloadDir := file(".dynamodb-local")
 dynamoDBLocalPort := 8042


### PR DESCRIPTION
I quite often dip into the console to validate things and without this, it becomes pretty unusable.