### PR TITLE
Add `returnValues` support for put/update/delete operations

### DIFF
--- a/src/main/scala/com/gu/scanamo/ops/ScanamoInterpreters.scala
+++ b/src/main/scala/com/gu/scanamo/ops/ScanamoInterpreters.scala
@@ -158,7 +158,10 @@ private[ops] object JavaRequests {
 
   def put(req: ScanamoPutRequest): PutItemRequest =
     req.condition.foldLeft(
-      new PutItemRequest().withTableName(req.tableName).withItem(req.item.getM)
+      new PutItemRequest()
+        .withTableName(req.tableName)
+        .withItem(req.item.getM)
+        .withReturnValues(req.returnValue.getOrElse(ReturnValue.NONE))
     )((r, c) =>
       c.attributeValues.foldLeft(
         r.withConditionExpression(c.expression).withExpressionAttributeNames(c.attributeNames.asJava)
@@ -167,7 +170,10 @@ private[ops] object JavaRequests {
 
   def delete(req: ScanamoDeleteRequest): DeleteItemRequest =
     req.condition.foldLeft(
-      new DeleteItemRequest().withTableName(req.tableName).withKey(req.key.asJava)
+      new DeleteItemRequest()
+        .withTableName(req.tableName)
+        .withKey(req.key.asJava)
+        .withReturnValues(req.returnValue.getOrElse(ReturnValue.NONE))
     )((r, c) =>
       c.attributeValues.foldLeft(
         r.withConditionExpression(c.expression).withExpressionAttributeNames(c.attributeNames.asJava)
@@ -179,7 +185,7 @@ private[ops] object JavaRequests {
       new UpdateItemRequest().withTableName(req.tableName).withKey(req.key.asJava)
         .withUpdateExpression(req.updateExpression)
         .withExpressionAttributeNames(req.attributeNames.asJava)
-        .withReturnValues(ReturnValue.ALL_NEW)
+        .withReturnValues(req.returnValue.getOrElse(ReturnValue.ALL_NEW))
     )((r, c) =>
       c.attributeValues.foldLeft(
         r.withConditionExpression(c.expression).withExpressionAttributeNames(

--- a/src/main/scala/com/gu/scanamo/request/ScanamoRequest.scala
+++ b/src/main/scala/com/gu/scanamo/request/ScanamoRequest.scala
@@ -1,18 +1,20 @@
 package com.gu.scanamo.request
 
-import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import com.amazonaws.services.dynamodbv2.model.{AttributeValue, ReturnValue}
 import com.gu.scanamo.query.{Condition, Query}
 
 case class ScanamoPutRequest(
   tableName: String,
   item: AttributeValue,
-  condition: Option[RequestCondition]
+  condition: Option[RequestCondition],
+  returnValue: Option[ReturnValue]
 )
 
 case class ScanamoDeleteRequest(
   tableName: String,
   key: Map[String, AttributeValue],
-  condition: Option[RequestCondition]
+  condition: Option[RequestCondition],
+  returnValue: Option[ReturnValue]
 )
 
 case class ScanamoUpdateRequest(
@@ -21,7 +23,8 @@ case class ScanamoUpdateRequest(
   updateExpression: String,
   attributeNames: Map[String, String],
   attributeValues: Map[String, AttributeValue],
-  condition: Option[RequestCondition]
+  condition: Option[RequestCondition],
+  returnValue: Option[ReturnValue]
 )
 
 case class ScanamoScanRequest(


### PR DESCRIPTION
By setting `ReturnValues` for put, update and delete requests we will be able to get the item attributes as they appeared before they were updated.