### PR TITLE
Update documentation for the asynchronous interpreters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -156,7 +156,7 @@ lazy val docs = (project in file("docs"))
     addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc) in root, siteSubdirName in ScalaUnidoc in root)
   )
   .enablePlugins(MicrositesPlugin, SiteScaladocPlugin, GhpagesPlugin)
-  .dependsOn(scanamo % "compile->test")
+  .dependsOn(scanamo % "compile->test", alpakka % "compile")
 
 
 import ReleaseTransformations._

--- a/docs/src/main/tut/asynchronous.md
+++ b/docs/src/main/tut/asynchronous.md
@@ -4,7 +4,7 @@ title: Asynchronous Requests
 position: 7
 ---
 
-## Non-blocking requests
+## Asynchronous requests
  
 Whilst for simplicity most examples in these documents are based on synchronous
 requests to DynamoDB, Scanamo supports making the requests asynchronously with
@@ -38,3 +38,62 @@ val ops = for {
 ```
 
 Note that `AmazonDynamoDBAsyncClient` uses a thread pool internally.
+
+## Asynchronous and Non-blocking requests
+The `AmazonDynamoDBAsyncClient` is not *truly* asynchronous as it relies on 
+Java Futures which block as soon as you try to access the value within them. 
+Underneath the hood, they make use of a thread pool to perform a blocking call
+when making the HTTP request to DynamoDB. There is a possibility that you may
+not be able to reach your provisioned throughput because you have exhausted 
+the thread pool to make HTTP requests. Until Amazon switches to a truly 
+non-blocking implementation (backed by Netty), we have an Akka Streams based
+interpreter which is a truly non-blocking HTTP client. Scanamo supports 
+making non-blocking asynchronous HTTP requests with the Alpakka interpreter. 
+Using the Alpakka client means you need an `ActorSystem` and an 
+`ActorMaterializer` in order to make use of the streaming infrastructure
+that the Alpakka interpreter uses behind the scenes:
+
+```tut:silent
+import com.gu.scanamo._
+import com.gu.scanamo.syntax._
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import akka.stream.alpakka.dynamodb.scaladsl.DynamoClient
+import akka.stream.alpakka.dynamodb.impl.DynamoSettings
+import com.amazonaws.services.dynamodbv2.model.ScalarAttributeType._
+import scala.concurrent.duration._
+
+implicit val system = ActorSystem("scanamo-alpakka")
+implicit val materializer = ActorMaterializer.create(system)
+implicit val executor = system.dispatcher
+
+val alpakkaClient = DynamoClient(
+    DynamoSettings(
+      region = "",
+      host = "localhost",
+      port = 8042,
+      parallelism = 2
+    )
+)
+
+// Use the non-Alpakka client to create the table for tests
+val client = LocalDynamoDB.client()
+LocalDynamoDB.createTable(client)("nursery-farmers")('name -> S)
+
+case class Farm(animals: List[String])
+case class Farmer(name: String, age: Long, farm: Farm)
+val farmTable = Table[Farmer]("farm")
+val ops = for {
+  _ <- farmTable.putAll(Set(
+    Farmer("Boggis", 43L, Farm(List("chicken"))),
+    Farmer("Bunce", 52L, Farm(List("goose"))),
+    Farmer("Bean", 55L, Farm(List("turkey")))
+  ))
+  bunce <- farmTable.get('name -> "Bunce")
+} yield bunce
+
+// Use the Alpakka interpreter
+//concurrent.Await.result(ScanamoAlpakka.exec(alpakkaClient)(ops), 5.seconds)
+
+system.terminate()
+```

--- a/docs/src/main/tut/asynchronous.md
+++ b/docs/src/main/tut/asynchronous.md
@@ -97,3 +97,9 @@ val ops = for {
 
 system.terminate()
 ```
+
+In order to use the Alpakka interpreter, you need to import the `scanamo-alpakka` library dependency
+```sbt
+val scanamoV = "<latest scanamo version>"
+libraryDependencies += "com.gu" %% "scanamo-alpakka" % scanamoV
+```


### PR DESCRIPTION
Make the `docs` subproject depend on `scanamo` and `alpakka` subproject as we need Akka's `ActorSystem` and `ActorMaterializer` as they are dependencies needed for the Alpakka client to function.

**Note:** Don't bring in test files from alpakka as they interfere with scanamo's test files causing the Local DynamoDB to point to the wrong port.

